### PR TITLE
ctdb:tools:ctdb - add json output for 'ctdb ip'

### DIFF
--- a/ctdb/tools/ctdb.c
+++ b/ctdb/tools/ctdb.c
@@ -1639,7 +1639,7 @@ static bool print_ip_json(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
 	if (json_is_invalid(&jsobj)) {
 		return false;
 	}
-	jsnodes = json_get_array(&jsobj, "nodes");
+	jsnodes = json_get_array(&jsobj, "public_ips");
 	if (json_is_invalid(&jsnodes)) {
 		json_free(&jsobj);
 		return false;
@@ -1653,7 +1653,7 @@ static bool print_ip_json(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
 			goto failure;
 		}
 		a = ctdb_sock_addr_to_string(mem_ctx, &ips->ip[i].addr, false);
-		ret = json_add_string(&jsint, "public_ip", a);
+		ret = json_add_string(&jsint, "address", a);
 		if (ret != 0) {
 			json_free(&jsint);
 			goto failure;
@@ -1725,7 +1725,7 @@ static bool print_ip_json(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
 		}
 		TALLOC_FREE(a);
 	}
-	ret = json_add_object(&jsobj, "nodes", &jsnodes);
+	ret = json_add_object(&jsobj, "public_ips", &jsnodes);
 	if (ret != 0) {
 		goto failure;
 	}

--- a/debian/patches/ctdb-add-json-output-for-ip.patch
+++ b/debian/patches/ctdb-add-json-output-for-ip.patch
@@ -1,0 +1,188 @@
+From d58646c6b5ac0650c431d1d3bcd9334f47738233 Mon Sep 17 00:00:00 2001
+From: Andrew Walker <awalker@ixsystems.com>
+Date: Tue, 19 Jan 2021 08:05:19 -0500
+Subject: [PATCH] ctdb:tools:ctdb - add json output for 'ctdb ip'
+
+Add json output for the "ctdb ip" command. This is slightly differently
+formatted than the text version. "configured" is implicit in IP
+appearing in the list. Output has array of interfaces with boolean
+fields "active" and "available", and a string for the interface name.
+
+This commit also fixes return value of ctdb listnodes.
+---
+ ctdb/tools/ctdb.c | 131 ++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 127 insertions(+), 4 deletions(-)
+
+diff --git a/ctdb/tools/ctdb.c b/ctdb/tools/ctdb.c
+index 2ecdb7ee965..ea1989ce08e 100644
+--- a/ctdb/tools/ctdb.c
++++ b/ctdb/tools/ctdb.c
+@@ -1625,7 +1625,122 @@ static int ctdb_public_ip_cmp(const void *a, const void *b)
+ 	return ctdb_sock_addr_cmp(&ip_a->addr, &ip_b->addr);
+ }
+ 
+-static void print_ip(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
++static bool print_ip_json(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
++		     struct ctdb_public_ip_list *ips,
++		     struct ctdb_public_ip_info **ipinfo,
++		     bool all_nodes)
++{
++	unsigned int i, j;
++	struct json_object jsobj, jsnodes;
++	int ret;
++	char *json_output = NULL;
++
++	jsobj = json_new_object();
++	if (json_is_invalid(&jsobj)) {
++		return false;
++	}
++	jsnodes = json_get_array(&jsobj, "public_ips");
++	if (json_is_invalid(&jsnodes)) {
++		json_free(&jsobj);
++		return false;
++	}
++
++	for (i = 0; i < ips->num; i++) {
++		char *a = NULL;
++		struct json_object jsint, ifaces;
++		jsint = json_new_object();
++		if (json_is_invalid(&jsint)) {
++			goto failure;
++		}
++		a = ctdb_sock_addr_to_string(mem_ctx, &ips->ip[i].addr, false);
++		ret = json_add_string(&jsint, "address", a);
++		if (ret != 0) {
++			json_free(&jsint);
++			goto failure;
++		}
++		ret = json_add_int(&jsint, "pnn", ips->ip[i].pnn);
++		if (ret != 0) {
++			json_free(&jsint);
++			goto failure;
++		}
++
++		ifaces = json_get_array(&jsint, "interfaces");
++		if (json_is_invalid(&ifaces)) {
++			json_free(&jsint);
++			goto failure;
++		}
++
++		if (ipinfo[i] == NULL) {
++			goto skip_ipinfo;
++		}
++
++		for (j=0; j<ipinfo[i]->ifaces->num; j++) {
++			struct ctdb_iface *iface;
++			struct json_object to_add;
++			bool active, available;
++			to_add = json_new_object();
++			if (json_is_invalid(&to_add)) {
++				json_free(&jsint);
++				goto failure;
++			}
++
++			iface = &ipinfo[i]->ifaces->iface[j];
++			active = ipinfo[i]->active_idx == j ? true : false;
++			available = iface->link_state == 0 ? false : true;
++
++			ret = json_add_string(&to_add, "name", iface->name);
++			if (ret != 0) {
++				json_free(&jsint);
++				json_free(&to_add);
++				goto failure;
++			}
++			ret = json_add_bool(&to_add, "active", active);
++			if (ret != 0 ) {
++				json_free(&jsint);
++				json_free(&to_add);
++				goto failure;
++			}
++
++			ret = json_add_bool(&to_add, "available", available);
++			if (ret != 0) {
++				json_free(&jsint);
++				json_free(&to_add);
++				goto failure;
++			}
++			ret = json_add_object(&ifaces, NULL, &to_add);
++			if (ret != 0) {
++				json_free(&jsint);
++				goto failure;
++			}
++		}
++	skip_ipinfo:
++		ret = json_add_object(&jsint, "interfaces", &ifaces);
++		if (ret != 0) {
++			goto failure;
++		}
++
++		ret = json_add_object(&jsnodes, NULL, &jsint);
++		if (ret != 0) {
++			goto failure;
++		}
++		TALLOC_FREE(a);
++	}
++	ret = json_add_object(&jsobj, "public_ips", &jsnodes);
++	if (ret != 0) {
++		goto failure;
++	}
++	json_output = json_to_string(mem_ctx, &jsobj);
++	printf("%s\n", json_output);
++	TALLOC_FREE(json_output);
++	return true;
++failure:
++	json_free(&jsnodes);
++	json_free(&jsobj);
++	return false;
++}
++
++
++static bool print_ip(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
+ 		     struct ctdb_public_ip_list *ips,
+ 		     struct ctdb_public_ip_info **ipinfo,
+ 		     bool all_nodes)
+@@ -1724,6 +1839,7 @@ static void print_ip(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
+ 			       avail ? avail : "", conf ? conf : "");
+ 		}
+ 	}
++	return true;
+ }
+ 
+ static int collect_ips(uint8_t *keybuf, size_t keylen, uint8_t *databuf,
+@@ -1858,6 +1974,7 @@ static int control_ip(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
+ 	unsigned int i;
+ 	int ret;
+ 	bool do_all = false;
++	bool ok;
+ 
+ 	if (argc > 1) {
+ 		usage("ip");
+@@ -1910,8 +2027,14 @@ static int control_ip(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
+ 		}
+ 	}
+ 
+-	print_ip(mem_ctx, ctdb, ips, ipinfo, do_all);
+-	return 0;
++	switch (options.format) {
++	case F_JSON:
++		ok = print_ip_json(mem_ctx, ctdb, ips, ipinfo, do_all);
++		break;
++	default:
++		ok = print_ip(mem_ctx, ctdb, ips, ipinfo, do_all);
++	}
++	return ok ? 0 : 1;
+ }
+ 
+ static int control_ipinfo(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
+@@ -3928,7 +4051,7 @@ static int control_listnodes(TALLOC_CTX *mem_ctx, struct ctdb_context *ctdb,
+ 		ok = print_nodelist(mem_ctx, nodemap);
+ 	}
+ 
+-	return ok;
++	return ok ? 0 : 1;
+ }
+ 
+ static bool nodemap_identical(struct ctdb_node_map *nodemap1,
+-- 
+2.28.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ ctdb-tools-ctdb-add-JSON-output.patch
 s3-modules-smblibzfs-synchronize-with-FreeBSD.patch
 s3-utils-explicitly-free-cmdline_messaging_context.patch
 s3-utils-add-session-id-filter.patch
+ctdb-add-json-output-for-ip.patch


### PR DESCRIPTION
Add json output for the "ctdb ip" command. This is slightly differently
formatted than the text version. "configured" is implicit in IP
appearing in the list. Output has array of interfaces with boolean
fields "active" and "available", and a string for the interface name.

This commit also fixes returncode for the "ctdb listnodes" command.