### PR TITLE
s3:modules:shadow_copy_zfs - fix opens for deleted files

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -559,7 +559,7 @@ struct dataset_list *path_to_dataset_list(TALLOC_CTX *mem_ctx,
 		errno = ENOMEM;
 		return NULL;
 	}
-	ds = smb_zfs_path_get_dataset(lz, dl, path, true, false);
+	ds = smb_zfs_path_get_dataset(lz, dl, path, true, false, false);
 	if (ds == NULL) {
 		TALLOC_FREE(dl);
 		return NULL;
@@ -581,7 +581,7 @@ struct dataset_list *path_to_dataset_list(TALLOC_CTX *mem_ctx,
 		}
 		*slashp = '\0';
 		ds = smb_zfs_path_get_dataset(lz, dl, tmp_path,
-					      true, false);
+					      true, false, false);
 		if (ds == NULL) {
 			TALLOC_FREE(dl);
 			return NULL;
@@ -849,12 +849,13 @@ struct zfs_dataset *smb_zfs_path_get_dataset(struct smblibzfshandle *smblibzfsp,
 					     TALLOC_CTX *mem_ctx,
 					     const char *path,
 					     bool get_props,
-					     bool open_zhandle)
+					     bool open_zhandle,
+					     bool resolve_path)
 {
 	int ret;
 	struct zfs_dataset *dsout = NULL;
 	struct smbzhandle *zfs_ext = NULL;
-	ret = get_smbzhandle(smblibzfsp, mem_ctx, path, &zfs_ext, false);
+	ret = get_smbzhandle(smblibzfsp, mem_ctx, path, &zfs_ext, resolve_path);
 	if (ret != 0) {
 		DBG_ERR("Failed to get zhandle\n");
 		return NULL;

--- a/source3/modules/smb_libzfs.h
+++ b/source3/modules/smb_libzfs.h
@@ -223,10 +223,11 @@ int smb_zfs_set_user_prop(struct smbzhandle *hdl,
  * in the returned zfs_dataset struct.
  */
 struct zfs_dataset *smb_zfs_path_get_dataset(struct smblibzfshandle *smblibzfsp,
-                                             TALLOC_CTX *mem_ctx,
-                                             const char *path,
-                                             bool get_props,
-					     bool open_zhandle);
+					     TALLOC_CTX *mem_ctx,
+					     const char *path,
+					     bool get_props,
+					     bool open_zhandle,
+					     bool resolve_path);
 
 int smb_get_dataset_name(struct smbzhandle *zhandle_ext, const char **dataset_name_out);
 /*

--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -99,7 +99,7 @@ static struct zfs_dataset *shadow_path_to_dataset(struct dataset_list *dl,
 	 * memory context of our dataset list.
 	 */
 	child = smb_zfs_path_get_dataset(dl->root->zhandle->lz, dl,
-					 path, true, false);
+					 path, true, false, true);
 	if (child != NULL) {
 		DLIST_ADD(dl->children, child);
 		return child;

--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -89,7 +89,7 @@ static struct zfs_dataset *smbfname_to_ds(const struct connection_struct *conn,
 	}
 
 	child = smb_zfs_path_get_dataset(dl->root->zhandle->lz,
-					 dl, path, true, true);
+					 dl, path, true, true, true);
 	TALLOC_FREE(to_free);
 	if (child != NULL) {
 		DLIST_ADD(dl->children, child);


### PR DESCRIPTION
Pass through option to resolve path (remove non-existing path
components) to function to get zfs dataset handle. Goal here is to
get the zfs dataset handle so that we can enumerate snapshots for
the underlying filesystem (since there may be multiple nested
filesystems inside an SMB share). Once we have a snapshot list, we
can resolve the GMT token passed from SMB client to a particular
snapshot (based on snapshot creation time), and then convert the
path to one relative to the mountpoint for the resolved ZFS snapshot.
