### PR TITLE
NAS-111014 / 21.08 / Improve JSON support in samba

### DIFF
--- a/lib/audit_logging/audit_logging.h
+++ b/lib/audit_logging/audit_logging.h
@@ -93,5 +93,28 @@ _WARN_UNUSED_RESULT_ struct json_object json_get_object(
     struct json_object *object, const char *name);
 _WARN_UNUSED_RESULT_ char *json_to_string(TALLOC_CTX *mem_ctx,
 					  const struct json_object *object);
+
+_WARN_UNUSED_RESULT_ int iter_json_array(struct json_object *object,
+					 bool (*fn)(int index,
+						    struct json_object *entry,
+						    void *private_data),
+					 void *private_data);
+
+_WARN_UNUSED_RESULT_ int iter_json_object(struct json_object *object,
+					  bool (*fn)(const char *key,
+						     struct json_object *value,
+						     void *private_data),
+					  void *private_data);
+
+_WARN_UNUSED_RESULT_ int json_get_string_value(
+    const struct json_object *object, const char *key, const char **valp);
+_WARN_UNUSED_RESULT_ int json_get_bool_value(
+    const struct json_object *object, const char *key, bool *valp);
+_WARN_UNUSED_RESULT_ int json_get_int_value(
+    const struct json_object *object, const char *key, int *valp);
+_WARN_UNUSED_RESULT_ int json_get_array_value(
+    const struct json_object *object, const char *key, struct json_object *valp);
+
+_WARN_UNUSED_RESULT_ struct json_object load_json(const char *text);
 #endif
 #endif

--- a/source3/utils/net_groupmap.c
+++ b/source3/utils/net_groupmap.c
@@ -28,6 +28,15 @@
 #include "passdb.h"
 #include "lib/util/string_wrappers.h"
 
+#ifdef HAVE_JANSSON
+#include <jansson.h>
+#include "audit_logging.h"
+#define JS_MAJ_VER	0
+#define JS_MIN_VER	1
+#endif /* HAVE_JANSSON */
+
+bool is_batch_op = false;
+
 /*********************************************************
  Figure out if the input was an NT group or a SID string.
  Return the SID.
@@ -87,9 +96,396 @@ static void print_map_entry (const GROUP_MAP *map, bool long_list)
 	}
 
 }
+
+/*********************************************************
+ JSON helper functions
+**********************************************************/
+#ifdef HAVE_JANSSON
+static bool json_to_groupmap(struct json_object *jsdata,
+			     GROUP_MAP *map)
+{
+	const char *nt_name = NULL;
+	const char *comment = NULL;
+	const char *sid = NULL;
+	const char *group_type = NULL;
+	const char *unix_group = NULL;
+	int rid = 0, error, sid_type;
+
+	map->gid = -1;
+	map->sid_name_use = SID_NAME_DOM_GRP;
+
+	error = json_get_string_value(jsdata, "nt_name", &nt_name);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"nt_name\" must be string.\n"));
+			return false;
+		}
+	} else {
+		map->nt_name = talloc_strdup(map, nt_name);
+		if (map->nt_name == NULL) {
+			d_fprintf(stderr, _("memory error\n"));
+			return false;
+		}
+	}
+
+	error = json_get_int_value(jsdata, "rid", &rid);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"rid\" must be integer.\n"));
+			return false;
+		}
+	}
+
+	error = json_get_string_value(jsdata, "sid", &sid);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"sid\" must be string.\n"));
+			return false;
+		}
+	}
+
+	if (sid != NULL) {
+		bool ok;
+		const char *sid_endptr = NULL;
+		ok = dom_sid_parse_endp(sid, &map->sid, &sid_endptr);
+		if (!ok || (*sid_endptr != '\0')) {
+			d_fprintf(stderr, _("\"sid\" is invalid.\n"));
+			return false;
+		}
+	}
+	else if (rid != 0) {
+		sid_compose(&map->sid, get_global_sam_sid(), rid);
+	}
+	else if (nt_name != NULL) {
+		bool ok;
+		GROUP_MAP *tmp = NULL;
+		struct dom_sid *rv = NULL;
+
+		tmp = talloc_zero(talloc_tos(), GROUP_MAP);
+		if (tmp == NULL) {
+			return false;
+		}
+		ok = pdb_getgrnam(tmp, nt_name);
+		if (ok) {
+			rv = dom_sid_dup(map, &tmp->sid);
+			if (rv == NULL) {
+				TALLOC_FREE(tmp);
+				return false;
+			}
+			map->sid = *rv;
+		}
+		TALLOC_FREE(tmp);
+	}
+
+	error = json_get_int_value(jsdata, "gid", &map->gid);
+	if (error && (errno == EINVAL)) {
+		d_fprintf(stderr, _("Key [gid] must be an integer.\n"));
+		return false;
+	}
+
+	error = json_get_string_value(jsdata, "group_type_str", &group_type);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"group_type_str\" must be string.\n"));
+			return false;
+		}
+	} else {
+		switch (group_type[0]) {
+		case 'b':
+		case 'B':
+			map->sid_name_use = SID_NAME_WKN_GRP;
+			break;
+		case 'd':
+		case 'D':
+			map->sid_name_use = SID_NAME_DOM_GRP;
+			break;
+		case 'l':
+		case 'L':
+			map->sid_name_use = SID_NAME_ALIAS;
+			break;
+		default:
+			d_fprintf(stderr,
+				  _("unknown group type: %s\n"),
+				  group_type);
+			return false;
+		}
+	}
+
+	error = json_get_int_value(jsdata, "group_type", &sid_type);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"group_type\" must be integer.\n"));
+			return false;
+		}
+	} else {
+		switch(sid_type) {
+		case SID_NAME_WKN_GRP:
+		case SID_NAME_DOM_GRP:
+		case SID_NAME_ALIAS:
+			map->sid_name_use = sid_type;
+			break;
+		default:
+			d_fprintf(stderr, _("Invalid group type: %d\n"), sid_type);
+			return false;
+		}
+	}
+
+	error = json_get_string_value(jsdata, "unix_group", &unix_group);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"unix_group\" must be string.\n"));
+			return false;
+		}
+	} else {
+		struct group *grp = NULL;
+		grp = getgrnam(unix_group);
+		if (grp == NULL) {
+			d_fprintf(stderr, _("%s: getgrnam() failed: %s\n"),
+					 unix_group, strerror(errno));
+			return false;
+		}
+		map->gid = grp->gr_gid;
+	}
+	error = json_get_string_value(jsdata, "comment", &comment);
+	if (error) {
+		if (errno == EINVAL) {
+			d_fprintf(stderr, _("\"comment\" must be string.\n"));
+			return false;
+		}
+		map->comment = talloc_strdup(map, "");
+		if (map->comment == NULL) {
+			return false;
+		}
+	} else {
+		map->comment = talloc_strdup(map, comment);
+		if (map->comment == NULL) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool groupmap_to_json(struct json_object *gm_array,
+			     GROUP_MAP *map,
+			     bool verbose)
+{
+	struct json_object entry;
+	struct dom_sid_buf buf;
+	int error;
+
+	entry = json_new_object();
+	if (json_is_invalid(&entry)) {
+		return false;
+	}
+
+	error = json_add_string(&entry, "nt_name", map->nt_name);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_add_sid(&entry, "sid", &map->sid);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_add_int(&entry, "gid", map->gid);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_add_int(&entry, "group_type_int", map->sid_name_use);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_add_string(&entry, "comment", map->comment);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_add_int(&entry, "group_type_int", map->sid_name_use);
+	if (verbose) {
+		char *group = NULL;
+		const char *sid_type = sid_type_lookup(map->sid_name_use);
+
+		group = gidtoname(map->gid);
+		error = json_add_string(&entry, "unix_group", group);
+		TALLOC_FREE(group);
+		if (error) {
+			goto fail;
+		}
+
+		error = json_add_string(&entry, "group_type_str", sid_type);
+		if (error) {
+			goto fail;
+		}
+	}
+
+	error = json_add_object(gm_array, NULL, &entry);
+	if (error) {
+		goto fail;
+	}
+
+	return true;
+
+fail:
+	json_free(&entry);
+	return false;
+
+}
+#endif
+
 /*********************************************************
  List the groups.
 **********************************************************/
+#ifdef HAVE_JANSSON
+static int net_groupmap_list_json(struct net_context *c, int argc, const char **argv)
+{
+	size_t entries;
+	struct json_object jsdata, jsgroup = json_empty_object;
+	struct json_object output, gm_array;
+	bool verbose = false, ok;
+	int error;
+	char *jsout = NULL;
+
+	if (argc == 0) {
+		jsdata = json_new_object();
+		if (json_is_invalid(&jsdata)) {
+			return -1;
+		}
+	} else {
+		jsdata = load_json(argv[0]);
+		if (json_is_invalid(&jsdata)) {
+			return -1;
+		}
+	}
+
+	output = json_new_object();
+	if (json_is_invalid(&output)) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	gm_array = json_new_array();
+	if (json_is_invalid(&gm_array)) {
+		goto fail;
+	}
+
+	error = json_add_version(&output, JS_MAJ_VER, JS_MIN_VER);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_get_bool_value(&jsdata, "verbose", &verbose);
+	if (error && (errno != ENOENT)) {
+		goto fail;
+	}
+
+	if (json_object_get(jsdata.root, "group")) {
+		fstring sid;
+		GROUP_MAP *map = NULL;
+		struct dom_sid *to_check = NULL;
+
+		map = talloc_zero(to_check, GROUP_MAP);
+		if (map == NULL) {
+			goto fail;
+		}
+
+		jsgroup = json_get_object(&jsdata, "group");
+		if (json_is_invalid(&jsgroup)) {
+			goto fail;
+		}
+
+		map = talloc_zero(talloc_tos(), GROUP_MAP);
+		if (map == NULL) {
+			goto fail;
+		}
+
+		ok = json_to_groupmap(&jsgroup, map);
+		if (!ok) {
+			TALLOC_FREE(map);
+			goto fail;
+		}
+
+		sid_to_fstring(sid, &map->sid);
+		if (strncmp(sid, "S-0-0", 5) == 0) {
+			d_fprintf(stderr, _("\rid\", \"sid\", or \"nt_p\" "
+					    "is required for lookup of specific "
+					    "mapping.\n"));
+			TALLOC_FREE(map);
+			goto fail;
+		}
+
+		to_check = dom_sid_dup(talloc_tos(), &map->sid);
+		if (to_check == NULL) {
+			TALLOC_FREE(map);
+			goto fail;
+		}
+
+		if (!pdb_getgrsid(map, *to_check)) {
+			d_fprintf(stderr, _("Failed to locate group SID [%s] "
+					    "in the group database.\n"), sid);
+			TALLOC_FREE(map);
+			TALLOC_FREE(to_check);
+			goto fail;
+		}
+		TALLOC_FREE(to_check);
+
+		ok = groupmap_to_json(&gm_array, map, verbose);
+		if (!ok) {
+			TALLOC_FREE(map);
+			goto fail;
+		}
+
+		TALLOC_FREE(map);
+
+	} else {
+		GROUP_MAP **maps = NULL;
+		size_t entries;
+		int i;
+
+		ok = pdb_enum_group_mapping(NULL, SID_NAME_UNKNOWN,
+					    &maps, &entries, ENUM_ALL_MAPPED);
+		if (!ok) {
+			TALLOC_FREE(maps);
+			goto fail;
+		}
+
+		for (i = 0; i < entries; i++) {
+			bool ok;
+
+			ok = groupmap_to_json(&gm_array, maps[i], verbose);
+			if (!ok) {
+				TALLOC_FREE(maps);
+				goto fail;
+			}
+		}
+	}
+
+	error = json_add_object(&output, "groupmap", &gm_array);
+	if (error) {
+		goto fail;
+	}
+
+	jsout = json_to_string(talloc_tos(), &output);
+	if (jsout == NULL) {
+		goto fail;
+	}
+
+	printf("%s\n", jsout);
+	TALLOC_FREE(jsout);
+	json_free(&jsdata);
+	json_free(&output);
+	return 0;
+
+fail:
+	json_free(&output);
+	json_free(&jsdata);
+	return -1;
+}
+#endif /* HAVE_JANSSON */
+
 static int net_groupmap_list(struct net_context *c, int argc, const char **argv)
 {
 	size_t entries;
@@ -107,6 +503,12 @@ static int net_groupmap_list(struct net_context *c, int argc, const char **argv)
 		d_printf("%s\n%s\n", _("Usage: "), list_usage_str);
 		return 0;
 	}
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_list_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if (c->opt_verbose || c->opt_long_list_entries)
 		long_list = true;
@@ -190,6 +592,140 @@ static int net_groupmap_list(struct net_context *c, int argc, const char **argv)
 /*********************************************************
  Add a new group mapping entry
 **********************************************************/
+#ifdef HAVE_JANSSON
+static bool add_json_mapping(int idx, struct json_object *entry, void *state)
+{
+	bool ok;
+	GROUP_MAP *map = NULL, *tmp = NULL;
+	fstring sid;
+	int rid = -1;
+	NTSTATUS status;
+
+	map = talloc_zero(talloc_tos(), GROUP_MAP);
+	if (map == NULL) {
+		d_fprintf(stderr, _("memory error.\n"));
+		return false;
+	}
+
+	ok = json_to_groupmap(entry, map);
+	if (!ok) {
+		d_fprintf(stderr, _("[%d]: Failed to convert entry to "
+				    "GROUP_MAP.\n"), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	if (map->gid == -1) {
+		d_fprintf(stderr,
+			  _("[%d]: unable to determine group id for "
+			    "mapping group. Either \"gid\" or valid "
+			    "\"unix_group\" is required.\n"), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+	else if (!map->nt_name[0]) {
+		d_fprintf(stderr,
+			  _("[%d]: \"nt_name\" is required when \"gid\" is "
+			    "not specified."), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	tmp = talloc_zero(talloc_tos(), GROUP_MAP);
+	if (tmp == NULL) {
+		d_fprintf(stderr, _("memory error.\n"));
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	tmp->sid_name_use = SID_NAME_DOM_GRP;
+	if (pdb_getgrgid(tmp, map->gid)) {
+		sid_to_fstring(sid, &map->sid);
+		d_fprintf(stderr, _("[%d] unix gid %d already mapped to SID %s\n"),
+				    idx, map->gid, sid);
+		TALLOC_FREE(map);
+		TALLOC_FREE(tmp);
+		return false;
+	}
+	TALLOC_FREE(tmp);
+
+	sid_to_fstring(sid, &map->sid);
+	if (strequal(sid, "S-0-0")) {
+		if (pdb_capabilities() & PDB_CAP_STORE_RIDS) {
+			if (!pdb_new_rid(&rid)) {
+				d_fprintf(stderr,
+					  _("[%d]: Failed to allocate "
+					    "new RID.\n"), idx);
+				return false;
+			}
+		} else {
+			rid = algorithmic_pdb_gid_to_group_rid(map->gid);
+		}
+	}
+
+	if (rid != -1) {
+		struct dom_sid thesid;
+		sid_compose(&thesid, get_global_sam_sid(), rid);
+		sid_to_fstring(sid, &thesid);
+	}
+
+
+	status = add_initial_entry(map->gid,
+				   sid,
+				   map->sid_name_use,
+				   map->nt_name,
+				   map->comment);
+
+	TALLOC_FREE(map);
+
+	if (!NT_STATUS_IS_OK(status)) {
+		d_fprintf(stderr,
+			  _("[%s] failed to add entry for gid %d\n"),
+			  idx, map->gid);
+		return false;
+	}
+
+	return true;
+}
+
+static int net_groupmap_add_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object jsdata, jsgroupmap;
+	int error;
+	bool quiet = false;
+
+	jsdata = load_json(argv[0]);
+	if (json_is_invalid(&jsdata)) {
+		return -1;
+	}
+
+	error = json_get_bool_value(&jsdata, "quiet", &quiet);
+	if (error && (errno == EINVAL)) {
+		d_fprintf(stderr, _("key \"quiet\" must be boolean.\n"));
+		json_free(&jsdata);
+		return -1;
+	}
+
+	jsgroupmap = json_get_array(&jsdata, "groupmap");
+	if (json_is_invalid(&jsgroupmap)) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	error = iter_json_array(&jsgroupmap, add_json_mapping, NULL);
+	if (error) {
+		json_free(&jsdata);
+		return -1;
+	}
+	json_free(&jsdata);
+
+	if (!quiet && !is_batch_op) {
+		net_groupmap_list_json(c, argc, argv);
+	}
+
+	return 0;
+}
+#endif /* HAVE_JANSSON */
 
 static int net_groupmap_add(struct net_context *c, int argc, const char **argv)
 {
@@ -204,7 +740,6 @@ static int net_groupmap_add(struct net_context *c, int argc, const char **argv)
 	gid_t gid;
 	int i;
 	GROUP_MAP *map;
-
 	const char *name_type;
 	const char add_usage_str[] = N_("net groupmap add "
 					"{rid=<int>|sid=<string>}"
@@ -214,6 +749,12 @@ static int net_groupmap_add(struct net_context *c, int argc, const char **argv)
 					"[comment=<string>]");
 
 	name_type = "domain group";
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_add_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if (c->display_usage) {
 		d_printf("%s\n%s\n", _("Usage:\n"), add_usage_str);
@@ -364,6 +905,141 @@ static int net_groupmap_add(struct net_context *c, int argc, const char **argv)
 	return 0;
 }
 
+#ifdef HAVE_JANSSON
+static bool mod_json_mapping(int idx, struct json_object *entry, void *state)
+{
+	bool ok;
+	GROUP_MAP *map = NULL, *to_set = NULL;
+	fstring sid;
+	int rid = -1;
+	NTSTATUS status;
+
+	map = talloc_zero(talloc_tos(), GROUP_MAP);
+	if (map == NULL) {
+		d_fprintf(stderr, _("memory error.\n"));
+		return false;
+	}
+
+	ok = json_to_groupmap(entry, map);
+	if (!ok) {
+		d_fprintf(stderr, _("[%d]: Failed to convert entry to "
+				    "GROUP_MAP.\n"), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	sid_to_fstring(sid, &map->sid);
+	if (strequal(sid, "S-0-0")) {
+		d_fprintf(stderr,
+			  _("[%d]: either \"sid\" or \"nt_name\" "
+			    "is required.\n"), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	to_set = talloc_zero(talloc_tos(), GROUP_MAP);
+	if (to_set == NULL) {
+		d_fprintf(stderr, _("memory error.\n"));
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	ok = pdb_getgrsid(to_set, map->sid);
+	if (!ok) {
+		d_fprintf(stderr,
+			  _("[%d]: Failed to find sid %s in database\n"),
+			  idx, sid);
+		goto fail;
+	}
+
+	if (map->sid_name_use == SID_NAME_UNKNOWN) {
+		d_fprintf(stderr,
+			  _("[%d] Can't map to an unknown group type.\n"), idx);
+		goto fail;
+	}
+
+	if (to_set->sid_name_use == SID_NAME_WKN_GRP) {
+		d_fprintf(stderr,
+			  _("[%d] Can only change between domain and local.\n"), idx);
+		goto fail;
+	}
+
+	to_set->sid_name_use = map->sid_name_use;
+
+	if (map->comment[0]) {
+		to_set->comment = talloc_strdup(to_set, map->comment);
+		if (to_set->comment == NULL) {
+			d_fprintf(stderr, _("memory error.\n"));
+			goto fail;
+		}
+	}
+
+	if (map->gid != -1) {
+		to_set->gid = map->gid;
+	}
+
+	if (map->nt_name[0]) {
+		to_set->nt_name = talloc_strdup(to_set, map->nt_name);
+		if (to_set->nt_name == NULL) {
+			d_fprintf(stderr, _("memory error.\n"));
+			goto fail;
+		}
+	}
+
+	status = pdb_update_group_mapping_entry(map);
+	if (!NT_STATUS_IS_OK(status)) {
+		goto fail;
+	}
+
+	TALLOC_FREE(map);
+	TALLOC_FREE(to_set);
+	return true;
+
+fail:
+	TALLOC_FREE(map);
+	TALLOC_FREE(to_set);
+	return false;
+}
+
+static int net_groupmap_modify_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object jsdata, jsgroupmap;
+	int error;
+	bool quiet = false;
+
+	jsdata = load_json(argv[0]);
+	if (json_is_invalid(&jsdata)) {
+		return -1;
+	}
+
+	error = json_get_bool_value(&jsdata, "quiet", &quiet);
+	if (error && (errno == EINVAL)) {
+		d_fprintf(stderr, _("key \"quiet\" must be boolean.\n"));
+		json_free(&jsdata);
+		return -1;
+	}
+
+	jsgroupmap = json_get_array(&jsdata, "groupmap");
+	if (json_is_invalid(&jsgroupmap)) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	error = iter_json_array(&jsgroupmap, mod_json_mapping, NULL);
+	if (error) {
+		json_free(&jsdata);
+		return -1;
+	}
+	json_free(&jsdata);
+
+	if (!quiet && !is_batch_op) {
+		net_groupmap_list_json(c, argc, argv);
+	}
+
+	return 0;
+}
+#endif /* HAVE_JANSSON */
+
 static int net_groupmap_modify(struct net_context *c, int argc, const char **argv)
 {
 	struct dom_sid sid;
@@ -381,6 +1057,12 @@ static int net_groupmap_modify(struct net_context *c, int argc, const char **arg
 					   "[comment=<string>] "
 					   "[unixgroup=<string>] "
 					   "[type=<domain|local>]");
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_modify_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if (c->display_usage) {
 		d_printf("%s\n%s\n", _("Usage:\n"), modify_usage_str);
@@ -533,6 +1215,88 @@ static int net_groupmap_modify(struct net_context *c, int argc, const char **arg
 	return 0;
 }
 
+#ifdef HAVE_JANSSON
+static bool del_json_mapping(int idx, struct json_object *entry, void *state)
+{
+	bool ok;
+	GROUP_MAP *map = NULL;
+	fstring sid;
+	NTSTATUS status;
+
+	map = talloc_zero(talloc_tos(), GROUP_MAP);
+	if (map == NULL) {
+		d_fprintf(stderr, _("memory error.\n"));
+		return false;
+	}
+
+	ok = json_to_groupmap(entry, map);
+	if (!ok) {
+		d_fprintf(stderr, _("[%d]: Failed to convert entry to "
+				    "GROUP_MAP.\n"), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	sid_to_fstring(sid, &map->sid);
+	if (strequal(sid, "S-0-0")) {
+		d_fprintf(stderr,
+			  _("[%d]: either \"sid\" or \"nt_name\" "
+			    "is required.\n"), idx);
+		TALLOC_FREE(map);
+		return false;
+	}
+
+	status = pdb_delete_group_mapping_entry(map->sid);
+	if (!NT_STATUS_IS_OK(status)) {
+		d_fprintf(stderr,
+			  _("[%d]: Failed to remove SID %s from the mapping db!\n"),
+			  idx, sid);
+		return false;
+	}
+	TALLOC_FREE(map);
+
+	return true;
+}
+
+static int net_groupmap_delete_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object jsdata, jsgroupmap;
+	int error;
+	bool quiet = false;
+
+	jsdata = load_json(argv[0]);
+	if (json_is_invalid(&jsdata)) {
+		return -1;
+	}
+
+	error = json_get_bool_value(&jsdata, "quiet", &quiet);
+	if (error && (errno == EINVAL)) {
+		d_fprintf(stderr, _("key \"quiet\" must be boolean.\n"));
+		json_free(&jsdata);
+		return -1;
+	}
+
+	jsgroupmap = json_get_array(&jsdata, "groupmap");
+	if (json_is_invalid(&jsgroupmap)) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	error = iter_json_array(&jsgroupmap, del_json_mapping, NULL);
+	if (error) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	json_free(&jsdata);
+
+	if (!quiet && !is_batch_op) {
+		net_groupmap_list_json(c, 0, NULL);
+	}
+	return 0;
+}
+#endif /* HAVE_JANSSON */
+
 static int net_groupmap_delete(struct net_context *c, int argc, const char **argv)
 {
 	struct dom_sid sid;
@@ -541,6 +1305,12 @@ static int net_groupmap_delete(struct net_context *c, int argc, const char **arg
 	int i;
 	const char delete_usage_str[] = N_("net groupmap delete "
 					   "{ntgroup=<string>|sid=<SID>}");
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_delete_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if (c->display_usage) {
 		d_printf("%s\n%s\n", _("Usage:\n"), delete_usage_str);
@@ -785,9 +1555,125 @@ static int net_groupmap_cleanup(struct net_context *c, int argc, const char **ar
 	return 0;
 }
 
+#ifdef HAVE_JANSSON
+struct alias_member_token {
+	struct dom_sid *alias;
+	struct dom_sid *members;
+	uint32_t n_members;
+};
+
+static bool add_member_sid(int idx, struct json_object *member, void *private_data)
+{
+	struct alias_member_token *token = NULL;
+	const char *sid_string = NULL;
+	struct dom_sid member_sid;
+	int error;
+	NTSTATUS status;
+	bool ok;
+
+	token = talloc_get_type_abort(private_data, struct alias_member_token);
+	error = json_get_string_value(member, "sid", &sid_string);
+	if (error) {
+		d_fprintf(stderr, _("[%d]: \"sid\" string is required\n"), idx);
+		return false;
+	}
+
+	ok = string_to_sid(&member_sid, sid_string);
+	if (!ok) {
+		d_fprintf(stderr, _("[%d]: failed to convert %s to dom_sid\n"),
+			  idx, sid_string);
+		return false;
+	}
+	status = add_sid_to_array(token, &member_sid,
+				  &token->members, &token->n_members);
+	if (!NT_STATUS_IS_OK(status)) {
+		d_fprintf(stderr, _("[%d]: failed to add %s to members array\n"),
+			  idx, sid_string);
+		return false;
+	}
+	return true;
+}
+
+static bool json_to_sids(struct json_object *data, struct alias_member_token *token)
+{
+	int error;
+	const char *alias = NULL;
+	struct json_object members;
+
+	error = json_get_string_value(data, "alias", &alias);
+	if (error) {
+		return false;
+	}
+
+	token->alias = dom_sid_parse_talloc(token, alias);
+	if (token->alias == NULL) {
+		return false;
+	}
+
+	members = json_get_array(data, "members");
+	if (json_is_invalid(&members)) {
+		return false;
+	}
+
+	error = iter_json_array(&members, add_member_sid, token);
+	if (error) {
+		return false;
+	}
+	return true;
+}
+
+
+static int net_groupmap_addmem_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object jsdata;
+	bool ok;
+	struct alias_member_token *token = NULL;
+	int i;
+
+	jsdata = load_json(argv[0]);
+	if (json_is_invalid(&jsdata)) {
+		return -1;
+	}
+
+	token = talloc_zero(talloc_tos(), struct alias_member_token);
+	if (token == NULL) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	ok = json_to_sids(&jsdata, token);
+	if (!ok) {
+		printf("json to sids failed\n");
+		json_free(&jsdata);
+		return -1;
+	}
+	json_free(&jsdata);
+
+	for (i = 0; i < token->n_members; i++) {
+		NTSTATUS status;
+		status = pdb_add_aliasmem(token->alias, &token->members[i]);
+		if (!NT_STATUS_IS_OK(status)) {
+			d_fprintf(stderr, _("[%d]: failed to add member: %s\n"),
+				  i, nt_errstr(status));
+			TALLOC_FREE(token);
+			return -1;
+		}
+	}
+
+	TALLOC_FREE(token);
+	return 0;
+}
+#endif /* HAVE_JANSSON */
+
 static int net_groupmap_addmem(struct net_context *c, int argc, const char **argv)
 {
 	struct dom_sid alias, member;
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_addmem_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if ( (argc != 2) ||
 	     c->display_usage ||
@@ -808,9 +1694,58 @@ static int net_groupmap_addmem(struct net_context *c, int argc, const char **arg
 	return 0;
 }
 
+#ifdef HAVE_JANSSON
+static int net_groupmap_delmem_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object jsdata;
+	bool ok;
+	struct alias_member_token *token = NULL;
+	int i;
+
+	jsdata = load_json(argv[0]);
+	if (json_is_invalid(&jsdata)) {
+		return -1;
+	}
+
+	token = talloc_zero(talloc_tos(), struct alias_member_token);
+	if (token == NULL) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	ok = json_to_sids(&jsdata, token);
+	if (!ok) {
+		printf("json to sids failed\n");
+		json_free(&jsdata);
+		return -1;
+	}
+	json_free(&jsdata);
+
+	for (i = 0; i < token->n_members; i++) {
+		NTSTATUS status;
+		status = pdb_del_aliasmem(token->alias, &token->members[i]);
+		if (!NT_STATUS_IS_OK(status)) {
+			d_fprintf(stderr, _("[%d]: failed to add member: %s\n"),
+				  i, nt_errstr(status));
+			TALLOC_FREE(token);
+			return -1;
+		}
+	}
+
+	TALLOC_FREE(token);
+	return 0;
+}
+#endif /* HAVE_JANSSON */
+
 static int net_groupmap_delmem(struct net_context *c, int argc, const char **argv)
 {
 	struct dom_sid alias, member;
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_delmem_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if ( (argc != 2) ||
 	     c->display_usage ||
@@ -831,11 +1766,125 @@ static int net_groupmap_delmem(struct net_context *c, int argc, const char **arg
 	return 0;
 }
 
+#ifdef HAVE_JANSSON
+static int net_groupmap_listmem_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object jsdata, out, jsmembers;
+	bool ok;
+	struct alias_member_token *token = NULL;
+	int i, error;
+	size_t num;
+	struct dom_sid *members = NULL;
+	char *toprint= NULL;
+	NTSTATUS status;
+
+	jsdata = load_json(argv[0]);
+	if (json_is_invalid(&jsdata)) {
+		return -1;
+	}
+
+	token = talloc_zero(talloc_tos(), struct alias_member_token);
+	if (token == NULL) {
+		json_free(&jsdata);
+		return -1;
+	}
+
+	ok = json_to_sids(&jsdata, token);
+	if (!ok) {
+		printf("json to sids failed\n");
+		json_free(&jsdata);
+		return -1;
+	}
+	json_free(&jsdata);
+
+	out = json_new_object();
+	if (json_is_invalid(&out)) {
+		d_fprintf(stderr, _("Failed to create JSON object %s\n"));
+		TALLOC_FREE(token);
+		return -1;
+	}
+
+	jsmembers = json_new_array();
+	if (json_is_invalid(&jsmembers)) {
+		d_fprintf(stderr, _("Failed to create JSON object %s\n"));
+		json_free(&out);
+		TALLOC_FREE(token);
+		return -1;
+	}
+
+	error = json_add_version(&out, JS_MAJ_VER, JS_MIN_VER);
+	if (error) {
+		goto fail;
+	}
+
+	error = json_add_sid(&out, "alias", token->alias);
+	if (error) {
+		goto fail;
+	}
+
+	status = pdb_enum_aliasmem(token->alias, talloc_tos(),
+				   &members, &num);
+	if (!NT_STATUS_IS_OK(status)) {
+		d_fprintf(stderr, _("Failed to enumerate alias members: %s\n"),
+			  nt_errstr(status));
+		goto fail;
+	}
+
+	for (i = 0; i < num; i++) {
+		struct json_object member;
+		member = json_new_object();
+		if (json_is_invalid(&member)) {
+			goto fail;
+		}
+
+		error = json_add_sid(&member, "sid", &members[i]);
+		if (error) {
+			json_free(&member);
+			goto fail;
+		}
+
+		error = json_add_object(&jsmembers, NULL, &member);
+		if (error) {
+			goto fail;
+		}
+	}
+
+	error = json_add_object(&out, "members", &jsmembers);
+	if (error) {
+		json_free(&out);
+		TALLOC_FREE(token);
+		return -1;
+	}
+
+	toprint = json_to_string(token, &out);
+	printf("%s\n", toprint);
+	TALLOC_FREE(token);
+	json_free(&out);
+	return 0;
+
+fail:
+	json_free(&out);
+	json_free(&jsmembers);
+	TALLOC_FREE(token);
+	if (NT_STATUS_EQUAL(status, NT_STATUS_NO_SUCH_ALIAS)) {
+		return ENOENT;
+	}
+	return -1;
+
+}
+#endif
+
 static int net_groupmap_listmem(struct net_context *c, int argc, const char **argv)
 {
 	struct dom_sid alias;
 	struct dom_sid *members;
 	size_t i, num;
+
+#ifdef HAVE_JANSSON
+	if (c->opt_json) {
+		return net_groupmap_listmem_json(c, argc, argv);
+	}
+#endif /* HAVE_JANSSON */
 
 	if ( (argc != 1) ||
 	     c->display_usage ||
@@ -929,6 +1978,117 @@ static int net_groupmap_memberships(struct net_context *c, int argc, const char 
 	return 0;
 }
 
+#ifdef HAVE_JANSSON
+const struct {
+	const char *name;
+	int (*fn)(struct net_context *c, int argc, const char **argv);
+} optable[] = {
+	{ "DEL", net_groupmap_delete },
+	{ "ADD", net_groupmap_add },
+	{ "MOD", net_groupmap_modify },
+	{ "DELMEM", net_groupmap_delmem },
+	{ "ADDMEM", net_groupmap_addmem },
+};
+
+struct batch_op_state {
+	struct net_context *ctx;
+	int (*fn)(struct net_context *c, int argc, const char **argv);
+};
+
+static bool dispatch_batch_op(int idx,
+			      struct json_object *data,
+			      void *private_data)
+{
+	int error;
+	struct batch_op_state *state = NULL;
+	char *js_data = NULL, *payload = NULL;
+
+	state = talloc_get_type_abort(private_data, struct batch_op_state);
+
+	payload = json_dumps(data->root, 0);
+	if (payload == NULL) {
+		d_fprintf(stderr, _("Failed to convert \"data\" to string.\n"));
+		return false;
+	}
+
+	const char *args[] = { payload, NULL };
+	error = state->fn(state->ctx, 1, args);
+	if (error) {
+		d_fprintf(stderr, _("operation failed on element: %d.\n"), idx);
+		return false;
+		free(js_data);
+	}
+	free(js_data);
+
+	return true;
+}
+
+static int net_groupmap_batch_json(struct net_context *c, int argc, const char **argv)
+{
+	struct json_object batch_data = json_empty_object;
+	size_t array_size;
+	int i, error;
+
+	is_batch_op = true;
+	batch_data = load_json(argv[0]);
+
+	if (batch_data.root == NULL) {
+		d_fprintf(stderr, _("Failed to load JSON data.\n"));
+		return false;
+	}
+
+	if (!json_is_object(batch_data.root)) {
+		d_fprintf(stderr, _("data is not a JSON object.\n"));
+		json_free(&batch_data);
+		return -1;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(optable); i++) {
+		struct json_object op_array;
+		struct batch_op_state *state = NULL;
+
+		op_array = json_get_array(&batch_data, optable[i].name);
+		if (json_is_invalid(&op_array)) {
+			continue;
+		}
+
+		state = talloc_zero(talloc_tos(), struct batch_op_state);
+		if (state == NULL) {
+			d_fprintf(stderr, _("memory error\n"));
+			json_free(&batch_data);
+			return -1;
+		}
+
+		state->ctx = c;
+		state->fn = optable[i].fn;
+
+		error = iter_json_array(&op_array, dispatch_batch_op, state);
+		if (error) {
+			d_fprintf(stderr,
+				  _("%s: operation failed\n"),
+				  optable[i].name);
+			json_free(&batch_data);
+			return -1;
+		}
+		TALLOC_FREE(state);
+	}
+
+	if (error) {
+		d_fprintf(stderr, _("No valid operations specified\n"));
+		json_free(&batch_data);
+	}
+
+	json_free(&batch_data);
+
+	error = net_groupmap_list(c, 0, NULL);
+	if (error) {
+		d_fprintf(stderr, _("failed to add updated groupmap\n"));
+	}
+
+	return 0;
+}
+#endif
+
 /***********************************************************
  migrated functionality from smbgroupedit
  **********************************************************/
@@ -1015,6 +2175,18 @@ int net_groupmap(struct net_context *c, int argc, const char **argv)
 			N_("net groupmap list\n"
 			   "    List current group map")
 		},
+#ifdef HAVE_JANSSON
+		{
+			"batch",
+			net_groupmap_batch_json,
+			NET_TRANSPORT_LOCAL,
+			N_("Perform multiple json operations"),
+			N_("net groupmap batch\n"
+			   "    Perform batch operation based on supplied JSON. "
+			   "    Current supported operations are \"ADD\", \"MOD\", \"DEL\" \n"
+			   "    '{ \"<OP>\": [ {ENTRY}, {ENTRY}, ... ]'")
+		},
+#endif
 		{NULL, NULL, 0, NULL, NULL}
 	};
 


### PR DESCRIPTION
This PR expands lib/audit_logging (current home of Samba JSON functions) to allow iteration of arrays and JSON objects, as well as some helper functions. These functions are then used to expand capabilities of net_groupmap. This was required to improve efficiency of group handling in TrueNAS as well as give more precise control over groupmap entries. Details are in commit messages for components of this PR. Brief version as follows:

*lib/audit_logging*
1) Add iterators for JSON objects and arrays.
Iterators require function pointer for callback
and have void pointer to pass into the callback.
JSON object iterator allows safe modification
of the parent object in callback.

2) Add function to load JSON from string and
return a struct json_object.

3) Add various helper functions to get data
from struct json_object based on type.
errno will be set to ENOENT if it key doesn't
exist, or EINVAL if the value is an incorrect
type.

*source3/utils/net_groupmap*
Add JSON variations of the major functions in net_groupmap.
"list", "add", "modify", "delete" take a list of JSON groupmaps
as an argument:
```
{"groupmap": [{<GROUPMAP>}, ...]}
```

"list" supports an additional key "verbose" which results in
returned groupmaps adding string for group SID type "group_type_str",
and getgrgid output for the unix group name "unix_name".
If no arguments are passed to "list" or if "groupmap" is an
empty list, then all entries are returned; otherwise, only
the entries specified in "groupmap" will be returned.

A sample JSON groupmap is as follows:
```
    {
      "nt_name": "Guests",
      "sid": "S-1-5-32-546",
      "gid": 546,
      "group_type_int": 5,
      "comment": "Wellknown Unix group"
    }
```

Incomplete groupmap entries can be submitted. For example,
`{"nt_name": "Osiris", "gid": 1666}` is sufficient to generate
a groupmap entry (with remaining values being auto-generated).

"add", "modify", and "delete" will print the updated groupmap
entries (or whole list in the last case) to stdout on success.

"listmem", "addmem", "delmem" commands take the following as a
payload:
```
{"alias": <sid string>, "members": [{"sid": <sid string>}, ...]}
```

A new command `batch` is also added in this commit. This allows
batching up various operations to be performed. Payload is
as follows:
```
{<OP>: [{cmd args}, ...], <OP>: [{cmd args}, ...]}
```
where `<cmd_args>` are the arguments that would normally be submitted to the command associated with `<OP>`.

Supported ops are ADD, MOD, DEL, ADDMEM, DELMEM.