### PR TITLE
NAS-109335 / 21.08 / s3:modules:vfs_zfs_core - fix ACL inheritance on DS creation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+samba (2:4.14.5+ix-1) unstable; urgency=medium
+
+  * Update to Samba 4.14.5 and fix issue with automatic dataset
+    creation.
+
+ -- Andrew Walker <awalker@ixsystems.com>  Tue, 29 Jun 2021 17:00:00 +0000
+
+
 samba (2:4.14.2+ix-3) unstable; urgency=medium
 
   * Fix json_decref() of uninitialized memory, and return EEXIST


### PR DESCRIPTION
Initial implementation of automatic ZFS dataset creation
was platform-specific due to using FreeBSD acl-related
syscalls to perform inheritance. This commit converts
these operations to be fully platform agnostic by plumbing
ACL inheritance implementation through samba's VFS where
practical.

Due to the need to fully initialize VFS modules (which
often occurs in vfs_connect_fn(), it was necessary to
break the dataset creation and ACL inheritance into two
separate steps. In vfs_connect_fn() datasets are created
as required, and results of auto-creation are stored
in struct dataset_list that is allocated under a long-lived
context (handle->conn), which won't be freed until
tree disconnect (or session termination). This only occurs
during user's first tree connect to share, and so extra
allocation is not an issue. ACL inheritance is performed
in vfs_chdir_fn() which is called first during session setup
subsequent to tree connect / authentication. During this
step we check to see whether there is a stored dataset_list
and walk up each dataset that was added, inheriting the ACL
from the parent dataset. Whether check has been performed is
stored on stack and so this will only be performed once
per tree connect (necessitated since chdir() can be called
extremely frequently during symlink safety checks).