### PR TITLE
NAS-110166 / 21.08 / packaging:systemd - link winbind and smb systemd units

### DIFF
--- a/packaging/systemd/smb.service.in
+++ b/packaging/systemd/smb.service.in
@@ -3,6 +3,7 @@ Description=Samba SMB Daemon
 Documentation=man:smbd(8) man:samba(7) man:smb.conf(5)
 Wants=network-online.target
 After=network.target network-online.target nmb.service winbind.service
+Requires=winbind.service
 
 [Service]
 Type=notify
@@ -16,4 +17,5 @@ LimitCORE=infinity
 @systemd_smb_extra@
 
 [Install]
+Also=winbind.service
 WantedBy=multi-user.target

--- a/packaging/systemd/winbind.service.in
+++ b/packaging/systemd/winbind.service.in
@@ -13,4 +13,5 @@ LimitCORE=infinity
 @systemd_winbind_extra@
 
 [Install]
+Alias=winbindd.service
 WantedBy=multi-user.target


### PR DESCRIPTION
Since TrueNAS 11.2 winbind has been a requirement for the SMB
service (to resolve BUILTIN / WELL-KNOWN SIDs). Likewise, it makes
little sense to have winbind running without proving SMB services.
Update the systemd unit files to reflect this reality.
