### PR TITLE
s3:module:zfs_core - ensure always have VALID_STAT for temp fsp

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+samba (2:4.14.5+ix-2) unstable; urgency=medium
+
+  * Ensure we always have valid stat for internal fsp open
+    that is used to set NT ACL on auto-generated ZFS datasets.
+
+ -- Andrew Walker <awalker@ixsystems.com>  Tue, 29 Jun 2021 17:00:00 +0000
+
 samba (2:4.14.5+ix-1) unstable; urgency=medium
 
   * Update to Samba 4.14.5 and fix issue with automatic dataset


### PR DESCRIPTION
Ensure we always have a valid stat structure inside fsp->fsp_name->st for
internal fsp structs that are generated when recursively setting permissions
on auto-generated dataset + ancestors. Failed VALID_STAT() check in
vfs_nfs4acl_xattr will cause ACL to not be applied.
