### PR TITLE
NAS-112398 / 21.10 / Fix issue with presenting shadow copies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+samba (2:4.15.0+ix-1) unstable; urgency=medium
+
+  * Add FSP extension for shadow copies.
+
+ -- Andrew Walker <awalker@ixsystems.com>  Fri, 24 Sep 2021 17:00:00 +0000
+
+
 samba (2:4.15.0+ix-0) unstable; urgency=medium
 
   * Port samba 4.15.


### PR DESCRIPTION
Add FSP extension during SMB_VFS_OPENAT() in shadow_copy_zfs
that contains information about ZFS snapshot and dataset.
Use this to determine whether a given struct smb_filename
has been converted to one relative to a ZFS snapshot directory.

Remove some vfs operations that are no longer relevant in 4.15.