### PR TITLE
NAS-112150 / 21.10 / s3:modules:nfs4_acl_xattr - unconditionally add SYNC on ALLOW

### DIFF
--- a/source3/modules/nfs4acl_xattr_xdr.c
+++ b/source3/modules/nfs4acl_xattr_xdr.c
@@ -317,6 +317,10 @@ static NTSTATUS nfs4acli_to_smb4acl(struct vfs_handle_struct *handle,
 		smbace.aceFlags = nace->flag;
 		smbace.aceMask = nace->access_mask;
 
+		if (smbace.aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE) {
+			smbace.aceMask |= SMB_ACE4_SYNCHRONIZE;
+		}
+
 		if (nace->iflag & ACEI4_SPECIAL_WHO) {
 			smbace.flags |= SMB_ACE4_ID_SPECIAL;
 


### PR DESCRIPTION
Synchronize entries are part of generic access rights in NTFS / SMB.
Legacy data written with vfs_zfsacl (not vfs_ixnas) may have
DACL entries that lack SYNCHRONIZE. This prevents access via this
module. Unconditionally granting on ALLOW entries has no functional
impact since this is not enforced in kernel or ZFS on Linux, but
it provides Windows / SMB clients what's expected.
