### PR TITLE
NAS-112638 / 21.10 / s3:modules:nfs4acl_xattr - add map_modify parameter

### DIFF
--- a/source3/modules/nfs4acl_xattr.h
+++ b/source3/modules/nfs4acl_xattr.h
@@ -35,6 +35,7 @@ struct nfs4acl_config {
 	enum default_acl_style default_acl_style;
 	bool nfs4_id_numeric;
 	bool validate_mode;
+	bool map_modify;
 };
 
 #endif /* __NFS4ACL_XATTR_H__ */

--- a/source3/modules/nfs4acl_xattr_xdr.c
+++ b/source3/modules/nfs4acl_xattr_xdr.c
@@ -337,6 +337,15 @@ static NTSTATUS nfs4acli_to_smb4acl(struct vfs_handle_struct *handle,
 				DBG_ERR("Unknown special id [%d]\n", nace->who);
 				continue;
 			}
+			if (config->map_modify &&
+			    (smbace.aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE) &&
+			    (smbace.aceMask & SMB_ACE4_WRITE_DATA)) {
+				smbace.aceMask |= (
+				    SMB_ACE4_DELETE |
+				    SMB_ACE4_WRITE_ATTRIBUTES |
+				    SMB_ACE4_WRITE_NAMED_ATTRS
+				);
+			}
 		} else {
 			if (nace->flag & ACE4_IDENTIFIER_GROUP) {
 				smbace.who.gid = nace->who;

--- a/source3/modules/vfs_nfs4acl_xattr.c
+++ b/source3/modules/vfs_nfs4acl_xattr.c
@@ -491,6 +491,11 @@ static int nfs4acl_connect(struct vfs_handle_struct *handle,
 					       "nfs4_id_numeric",
 					       false);
 
+	config->map_modify = lp_parm_bool(SNUM(handle->conn),
+					  "nfs4acl_xattr",
+					  "map_modify",
+					  true);
+
 
 	config->validate_mode = lp_parm_bool(SNUM(handle->conn),
 					     "nfs4acl_xattr",


### PR DESCRIPTION
Map POSIX write on special ACEs to WRITE|WRITE_ATTRIBUTE|DELETE|
WRITE_NAMED_ATTRS. This will allow users who insist on
misconfiguring ACLs by stripping them from an NFSv4 share to
get a rough approximation of GENERIC_WRITE through POSIX
write bit. It will also prevent chmod(2) from removing
write ability on paths.