### PR TITLE
NAS-112952 / 22.02-RC1 / s3:lib:adouble - do not assert if setting xattr on pathref

### DIFF
--- a/source3/lib/adouble.c
+++ b/source3/lib/adouble.c
@@ -2591,10 +2591,7 @@ int ad_fset(struct vfs_handle_struct *handle,
 
 	DBG_DEBUG("Path [%s]\n", fsp_str_dbg(fsp));
 
-	if ((fsp == NULL)
-	    || (fsp->fh == NULL)
-	    || (fsp_get_io_fd(fsp) == -1))
-	{
+	if ((fsp == NULL) || (fsp->fh == NULL)) {
 		smb_panic("bad fsp");
 	}
 
@@ -2612,6 +2609,9 @@ int ad_fset(struct vfs_handle_struct *handle,
 				   AD_DATASZ_XATTR, 0);
 		break;
 	case ADOUBLE_RSRC:
+		if (fsp_get_io_fd(fsp) == -1) {
+			smb_panic("Not an IO fd");
+		}
 		len = SMB_VFS_NEXT_PWRITE(handle,
 					  fsp,
 					  ad->ad_data,


### PR DESCRIPTION
Allow pathref fsp to pass through to NEXT_VFS_FSETXATTR.
vfs_default.c converts pathref calls to a procfd path and
is therefore safely handled. If for some reason we land
here with a pathref fsp on a AFP_RESOURCE write, assert
because this is unexpected.