### PR TITLE
NAS-113058 / 22.02-RC.2 / s3:modules:recycle - fix crash in recycle_internal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+samba (2:4.15.0+ix-2) unstable; urgency=medium
+
+  * Fix crash in vfs_recycle
+
+ -- Andrew Walker <awalker@ixsystems.com>  Wed, 27 Oct 2021 17:00:00 +0000
+
+
 samba (2:4.15.0+ix-1) unstable; urgency=medium
 
   * Add FSP extension for shadow copies.

--- a/source3/modules/vfs_recycle.c
+++ b/source3/modules/vfs_recycle.c
@@ -571,17 +571,9 @@ static int recycle_unlink_internal(vfs_handle_struct *handle,
 	 */
 
 	/* extract filename and path */
-	base = strrchr(full_fname->base_name, '/');
-	if (base == NULL) {
-		base = full_fname->base_name;
-		path_name = SMB_STRDUP("/");
-		ALLOC_CHECK(path_name, done);
-	}
-	else {
-		path_name = SMB_STRDUP(full_fname->base_name);
-		ALLOC_CHECK(path_name, done);
-		path_name[base - smb_fname->base_name] = '\0';
-		base++;
+	if (!parent_dirname(handle, full_fname->base_name, &path_name, &base)) {
+		errno = ENOMEM;
+		return -1;
 	}
 
 	/* original filename with path */
@@ -716,7 +708,7 @@ static int recycle_unlink_internal(vfs_handle_struct *handle,
 				 recycle_touch_mtime(handle));
 
 done:
-	SAFE_FREE(path_name);
+	TALLOC_FREE(path_name);
 	SAFE_FREE(temp_name);
 	SAFE_FREE(final_name);
 	TALLOC_FREE(full_fname);


### PR DESCRIPTION
Changes related to new samba VFS can result in crash while
splitting path into parent directory and base name. Use
appropriate internal standard samba function for doing this.
