### PR TITLE
s3:modules:smblibzfs - don't close zhandle when snapshotting

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -1166,7 +1166,6 @@ smb_zfs_snapshot(struct smbzhandle *hdl,
 		return -1;
 	}
 	dataset_name = zfs_get_name(zfsp);
-	zfs_close(zfsp);
 	ret = snprintf(snap, sizeof(snap), "%s@%s",
 		       dataset_name, snapshot_name);
 	if (ret < 0) {
@@ -1177,10 +1176,9 @@ smb_zfs_snapshot(struct smbzhandle *hdl,
 	ret = zfs_snapshot(hdl->lz->sli->libzfsp,
 			   snap, recursive, NULL);
 	if (ret != 0) {
-		DBG_ERR("Failed to create snapshot %s: [%s]\n",
+		DBG_ERR("Failed to create snapshot %s: %s\n",
 			snap, strerror(errno));
 	}
-	DBG_INFO("Successfully created snapshot: %s\n", snap);
 	return ret;
 }
 


### PR DESCRIPTION
Early in SCALE development, smb_libzfs was refactored to attempt
to re-use zfs dataset handles as much as possible. Unfortunately,
a residual zfs_close() in the zfs snapshot function was missed.
Since this only occurs during tree disconnect in vfs_tmprotect
it was overlooked in testing (since NULL dereference in this
case only occurs when client performs a tree disconnect and then
a subsequent tree connect to same share without closing SMB
session).
