### PR TITLE
NAS-113538 / Fix procfd handling for xattr-based alternate datastreams

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -448,6 +448,7 @@ static NTSTATUS ixnas_fget_nt_acl(struct vfs_handle_struct *handle,
 {
 	struct SMB4ACL_T *pacl = NULL;
 	TALLOC_CTX *frame = NULL;
+	struct files_struct *to_check = NULL;
 	NTSTATUS status;
 	acl_t bsdacl;
 	struct ixnas_config_data *config = NULL;
@@ -460,7 +461,8 @@ static NTSTATUS ixnas_fget_nt_acl(struct vfs_handle_struct *handle,
 		return SMB_VFS_NEXT_FGET_NT_ACL(handle, fsp, security_info, mem_ctx, ppdesc);
 	}
 
-	bsdacl = fsp_get_bsdacl(fsp);
+	to_check = fsp->base_fsp ? fsp->base_fsp : fsp;
+	bsdacl = fsp_get_bsdacl(to_check);
 	if (bsdacl == NULL) {
 		if ((errno == EINVAL) &&
 		    (fsp_get_acl_brand(fsp) == ACL_BRAND_POSIX)) {

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -355,6 +355,7 @@ static int streams_xattr_openat(struct vfs_handle_struct *handle,
 	 * For now assert this, so the below SMB_VFS_SETXATTR() works.
 	 */
 	SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+	fsp->fsp_flags.have_proc_fds = fsp->conn->have_proc_fds;
 
 	status = streams_xattr_get_name(handle, talloc_tos(),
 					smb_fname->stream_name, &xattr_name);


### PR DESCRIPTION
vfs_streams_xattr openat() does not set fsp.flags.have_proc_fds. In open_streams_for_delete() the fsp is not allocated via talloc_zero() and so this may be unitialized memory. 

This particular fix ensures vfs_streams_xattr sets the fsp have_proc_fds flag to the one defined in the associated tree connect for the fsp. In the case of vfs_ixnas, ensure that we read the NT ACL from fsp->base_fsp (file) rather than the fsp associated with the xattr.

This PR also fixes vfs_zfsacl for FreeBSD 13 (adding handling for procfd paths)