### PR TITLE
NAS-113555 / Fix stream removal through vfs_fruit

### DIFF
--- a/source3/modules/vfs_fruit.c
+++ b/source3/modules/vfs_fruit.c
@@ -209,6 +209,7 @@ static struct adouble *ad_get_meta_fsp(TALLOC_CTX *ctx,
 				       const struct smb_filename *smb_fname)
 {
 	NTSTATUS status;
+	int rc;
 	struct adouble *ad = NULL;
 	struct smb_filename *smb_fname_cp = NULL;
 	struct fruit_config_data *config = NULL;
@@ -232,6 +233,10 @@ static struct adouble *ad_get_meta_fsp(TALLOC_CTX *ctx,
 		return NULL;
 	}
 	TALLOC_FREE(smb_fname_cp->stream_name);
+
+	rc = SMB_VFS_NEXT_STAT(handle, smb_fname_cp);
+	SMB_ASSERT(rc == 0);
+
 	config->in_openat_pathref_fsp = true;
 	status = openat_pathref_fsp(handle->conn->cwd_fsp,
 				    smb_fname_cp);

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -355,12 +355,11 @@ static int streams_xattr_openat(struct vfs_handle_struct *handle,
 	 * For now assert this, so the below SMB_VFS_SETXATTR() works.
 	 */
 #ifdef O_EMPTY_PATH
-	if (!flags & O_EMPTY_PATH) {
-		SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+	if (flags & O_EMPTY_PATH) {
+		return vfs_fake_fd();
 	}
-#else
-	SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
 #endif
+	SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
 	fsp->fsp_flags.have_proc_fds = fsp->conn->have_proc_fds;
 
 	status = streams_xattr_get_name(handle, talloc_tos(),

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -354,7 +354,13 @@ static int streams_xattr_openat(struct vfs_handle_struct *handle,
 	/*
 	 * For now assert this, so the below SMB_VFS_SETXATTR() works.
 	 */
+#ifdef O_EMPTY_PATH
+	if (!flags & O_EMPTY_PATH) {
+		SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+	}
+#else
 	SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+#endif
 	fsp->fsp_flags.have_proc_fds = fsp->conn->have_proc_fds;
 
 	status = streams_xattr_get_name(handle, talloc_tos(),

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -1589,6 +1589,24 @@ static bool streams_xattr_strict_lock_check(struct vfs_handle_struct *handle,
 	return true;
 }
 
+static NTSTATUS streams_xattr_get_nt_acl(vfs_handle_struct *handle,
+					 files_struct *fsp,
+					 uint32_t security_info,
+					 TALLOC_CTX *mem_ctx,
+					 struct security_descriptor **ppdesc)
+{
+	struct files_struct *to_check = NULL;
+
+	to_check = fsp->base_fsp ? fsp->base_fsp : fsp;
+
+	return SMB_VFS_NEXT_FGET_NT_ACL(handle,
+					to_check,
+					security_info,
+					mem_ctx,
+					ppdesc);
+}
+
+
 static struct vfs_fn_pointers vfs_streams_xattr_fns = {
 	.fs_capabilities_fn = streams_xattr_fs_capabilities,
 	.connect_fn = streams_xattr_connect,
@@ -1608,6 +1626,8 @@ static struct vfs_fn_pointers vfs_streams_xattr_fns = {
 	.ftruncate_fn = streams_xattr_ftruncate,
 	.fallocate_fn = streams_xattr_fallocate,
 	.fstreaminfo_fn = streams_xattr_fstreaminfo,
+
+	.fget_nt_acl_fn = streams_xattr_get_nt_acl,
 
 	.fsync_send_fn = streams_xattr_fsync_send,
 	.fsync_recv_fn = streams_xattr_fsync_recv,

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -1189,14 +1189,17 @@ static NTSTATUS reopen_from_procfd(struct files_struct *fsp,
 	 */
 	proc_fname = (struct smb_filename) {
 		.base_name = "",
+		.stream_name = fsp->fsp_name->stream_name,
 	};
 
 	fsp->fsp_flags.is_pathref = false;
+	flags &= ~O_CREAT;
+	flags |= O_EMPTY_PATH;
 	new_fd = SMB_VFS_OPENAT(fsp->conn,
 				fsp,
 				&proc_fname,
 				fsp,
-				flags | O_EMPTY_PATH,
+				flags,
 				mode);
 
 #else


### PR DESCRIPTION
When removing all streams, we may end up having to remove
an AFP_Resource stream that is located in a separate file. In
this case, we should re-stat the file when doing operation
on base fsp in order to ensure that device and inode is
correct and opening a pathref fsp succeeds.