### PR TITLE
NAS-113240 / Always close connection when doing tdis

### DIFF
--- a/source3/smbd/smbXsrv_tcon.c
+++ b/source3/smbd/smbXsrv_tcon.c
@@ -913,6 +913,8 @@ NTSTATUS smbXsrv_tcon_disconnect(struct smbXsrv_tcon *tcon, uint64_t vuid)
 				  tcon->global->tcon_global_id,
 				  tcon->global->share_name,
 				  nt_errstr(status)));
+
+			close_cnum(tcon->compat, vuid);
 			tcon->compat = NULL;
 			return status;
 		}


### PR DESCRIPTION
This protects against use-after-free in subsequent tree disconnects
from the smbd process.
