### PR TITLE
NAS-113621 / s3:smbd:service.c - check for share access during tcon

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -388,6 +388,13 @@ typedef union unid_t {
 	gid_t gid;
 } unid_t;
 
+enum acl_brand {
+        SMB_ACL_BRAND_POSIX,
+        SMB_ACL_BRAND_NFS40,
+        SMB_ACL_BRAND_NFS41,
+        SMB_ACL_BRAND_NONE,
+};
+
 struct fd_handle;
 
 struct fsp_lease {
@@ -659,6 +666,7 @@ typedef struct files_struct {
  *
  * In any other case use fsp_get_io_fd().
  */
+#define TCON_FLAG_STAT_FAILED		0x01
 
 #define FSP_POSIX_FLAGS_OPEN		0x01
 #define FSP_POSIX_FLAGS_RENAME		0x02
@@ -707,6 +715,12 @@ typedef struct connection_struct {
 	   sub second timestamps on files
 	   and directories when setting time ? */
 	enum timestamp_set_resolution ts_res;
+
+	/* iXsystems additions */
+	enum acl_brand aclbrand;
+	uint32_t internal_tcon_flags;
+	/* end iXsystems additions */
+
 	char *connectpath;
 	struct files_struct *cwd_fsp; /* Working directory. */
 	bool tcon_done;

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -903,6 +903,11 @@ NTSTATUS fd_openat(const struct files_struct *dirfsp,
 	 * client should be doing this.
 	 */
 
+	if (fsp->conn->internal_tcon_flags & TCON_FLAG_STAT_FAILED) {
+		DBG_ERR("Tree connect initially failed access check. Denying access.\n");
+		return NT_STATUS_ACCESS_DENIED;
+	}
+
 	if ((fsp->posix_flags & FSP_POSIX_FLAGS_OPEN) || !lp_follow_symlinks(SNUM(conn))) {
 		flags |= O_NOFOLLOW;
 	}

--- a/source3/smbd/service.c
+++ b/source3/smbd/service.c
@@ -761,6 +761,27 @@ static NTSTATUS make_connection_snum(struct smbXsrv_connection *xconn,
 		}
 	}
 
+	smb_fname_cpath = synthetic_smb_fname(talloc_tos(),
+					conn->connectpath,
+					NULL,
+					NULL,
+					0,
+					0);
+	if (smb_fname_cpath == NULL) {
+		status = NT_STATUS_NO_MEMORY;
+		goto err_root_exit;
+	}
+
+	/*
+	 * Attempt to stat the share's connectpath as the current user
+	 * Windows allows tcon to succeed even if share access isn't allowed.
+	 * In this case though we'll set a flag to indicate that attempting
+	 * to stat() during TCON failed.
+	 */
+	if ((ret = SMB_VFS_STAT(conn, smb_fname_cpath)) != 0) {
+		conn->internal_tcon_flags |= TCON_FLAG_STAT_FAILED;
+	}
+
 #ifdef WITH_FAKE_KASERVER
 	if (lp_afs_share(snum)) {
 		afs_login(conn);
@@ -802,16 +823,6 @@ static NTSTATUS make_connection_snum(struct smbXsrv_connection *xconn,
 			       lp_veto_oplock_files(talloc_tos(), lp_sub, snum));
 		set_namearray( &conn->aio_write_behind_list,
 				lp_aio_write_behind(talloc_tos(), lp_sub, snum));
-	}
-	smb_fname_cpath = synthetic_smb_fname(talloc_tos(),
-					conn->connectpath,
-					NULL,
-					NULL,
-					0,
-					0);
-	if (smb_fname_cpath == NULL) {
-		status = NT_STATUS_NO_MEMORY;
-		goto err_root_exit;
 	}
 
 	/* win2000 does not check the permissions on the directory


### PR DESCRIPTION
Windows allows tree connects even when client lacks
filesystem access to the share. There are some edge
cases where the SMB client may request SMB2_CREATE
for file on share for which they lack traverse
rights. Add a check during tree connect for whether
user can stat() the share's connectpath. If this
fails, then set a flag in the connection_struct
indicated that access should be denied before
trying non-widelink opens in fd_open(). This
opens up edge case where user fixes permissions
issue, but existing SMB session still cannot access,
but I think this is suitably rare that we benefit
more from avoiding a failed non-widelink open and
subsequent panic when failing to chdir().