### PR TITLE
NAS-113980 / Add support for kernel dosmodes

### DIFF
--- a/docs-xml/smbdotconf/filename/kerneldosmodes.xml
+++ b/docs-xml/smbdotconf/filename/kerneldosmodes.xml
@@ -1,0 +1,13 @@
+<samba:parameter name="kernel dosmodes"
+                 context="S"
+                 type="boolean"
+                 xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<description>
+	<para>
+	This parameter is set to indicate that server supports kernel dosmodes.
+	In case they are enabled, normal dosmode storage in xattr / posix mode are bypassed
+	in favor of direct call to relevant SET/FSET_DOS_ATTRIBUTES vfs function.
+	</para>
+</description>
+<value type="default">no</value>
+</samba:parameter>

--- a/lib/param/loadparm.c
+++ b/lib/param/loadparm.c
@@ -2973,6 +2973,10 @@ struct loadparm_context *loadparm_init(TALLOC_CTX *mem_ctx)
 				  "65536");
 
 	lpcfg_do_global_parameter(lp_ctx,
+				  "kernel dosmodes",
+				  "False");
+
+	lpcfg_do_global_parameter(lp_ctx,
 				  "acl flag inherited canonicalization",
 				  "yes");
 

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -198,6 +198,7 @@ static const struct loadparm_service _sDefault =
 	.map_hidden = false,
 	.map_archive = true,
 	.store_dos_attributes = true,
+	.kernel_dosmodes = false,
 	.smbd_max_xattr_size = 65536,
 	.dmapi_support = false,
 	.locking = true,

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -209,6 +209,7 @@ access_denied:
 	if ((access_mask & FILE_WRITE_ATTRIBUTES) &&
 	    (rejected_mask & FILE_WRITE_ATTRIBUTES) &&
 	    !lp_store_dos_attributes(SNUM(conn)) &&
+	    !lp_kernel_dosmodes(SNUM(conn)) &&
 	    (lp_map_readonly(SNUM(conn)) ||
 	     lp_map_archive(SNUM(conn)) ||
 	     lp_map_hidden(SNUM(conn)) ||
@@ -3123,13 +3124,15 @@ static bool open_match_attributes(connection_struct *conn,
 		  (unsigned int)*returned_unx_mode ));
 
 	/* If we're mapping SYSTEM and HIDDEN ensure they match. */
-	if (lp_map_system(SNUM(conn)) || lp_store_dos_attributes(SNUM(conn))) {
+	if (lp_map_system(SNUM(conn)) || lp_store_dos_attributes(SNUM(conn)) ||
+	    lp_kernel_dosmodes(SNUM(conn))) {
 		if ((old_dos_attr & FILE_ATTRIBUTE_SYSTEM) &&
 		    !(new_dos_attr & FILE_ATTRIBUTE_SYSTEM)) {
 			return False;
 		}
 	}
-	if (lp_map_hidden(SNUM(conn)) || lp_store_dos_attributes(SNUM(conn))) {
+	if (lp_map_hidden(SNUM(conn)) || lp_store_dos_attributes(SNUM(conn)) ||
+	    lp_kernel_dosmodes(SNUM(conn))) {
 		if ((old_dos_attr & FILE_ATTRIBUTE_HIDDEN) &&
 		    !(new_dos_attr & FILE_ATTRIBUTE_HIDDEN)) {
 			return False;
@@ -4181,6 +4184,9 @@ static NTSTATUS open_file_ntcreate(connection_struct *conn,
 			file_id = make_file_id_from_itime(&smb_fname->st);
 			update_stat_ex_file_id(&smb_fname->st, file_id);
 		}
+		else if (lp_kernel_dosmodes(SNUM(conn))) {
+			/* TODO: derive fileid from getfh(2) output */
+		}
 	}
 
 	if (info != FILE_WAS_OPENED) {
@@ -4195,6 +4201,10 @@ static NTSTATUS open_file_ntcreate(connection_struct *conn,
 					unx_mode = smb_fname->st.st_ex_mode;
 				}
 			}
+		}
+		else if (lp_kernel_dosmodes(SNUM(conn)) && !posix_open) {
+			SMB_VFS_FSET_DOS_ATTRIBUTES(conn, smb_fname->fsp,
+					    new_dos_attributes | FILE_ATTRIBUTE_ARCHIVE);
 		}
 	}
 
@@ -4369,6 +4379,10 @@ static NTSTATUS mkdir_internal(connection_struct *conn,
 					 file_attributes | FILE_ATTRIBUTE_DIRECTORY,
 					 parent_dir_fname, true);
 		}
+	}
+	else if (lp_kernel_dosmodes(SNUM(conn)) && !posix_open) {
+		/* TODO: add file_id from getfh(2) on FreeBSD */
+		SMB_VFS_FSET_DOS_ATTRIBUTES(conn, fsp, file_attributes | FILE_ATTRIBUTE_DIRECTORY);
 	}
 
 	if (lp_inherit_permissions(SNUM(conn))) {


### PR DESCRIPTION
DOS attributes specified through SMB2 CREATE requests were not getting
set due to combination of parameters being used to enable kernel DOS
mode support and avoid extra xattr writes. This commit adds additional
handling for case where kernel DOS modes are supported and used by adding
new share-level parameter lp_kernel_dosmodes that is either manually set
or loaded at tcon by the VFS module. Additional check is made for kernel
DOS modes being enabled in code path for CREATE through SMB1/2 and the
relevant VFS operation called.
