### PR TITLE
NAS-114129 / s3:modules:zfs_core - fix quota size calculation

### DIFF
--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -254,7 +254,7 @@ static int zfs_core_set_quota(struct vfs_handle_struct *handle,
 		return -1;
 	}
 
-	zq.bytes = qt->hardlimit * 1024;
+	zq.bytes = qt->hardlimit * qt->bsize;
 	zq.obj = qt->ihardlimit;
 
 	switch (qtype) {


### PR DESCRIPTION
Take account of block size specified in quota request. This issue was fixed in 12.0-stable a long time ago, but not cherry-picked into SCALE / linux branch (because it was isolated in vfs_ixnas there).