### PR TITLE
NAS-114370 / s3:modules:ixnas - use inode generation for MS-FSCC file id

### DIFF
--- a/source3/include/includes.h
+++ b/source3/include/includes.h
@@ -193,6 +193,7 @@ typedef sig_atomic_t volatile SIG_ATOMIC_T;
 struct stat_ex {
 	dev_t		st_ex_dev;
 	ino_t		st_ex_ino;
+	uint64_t	st_ex_gen;
 	uint64_t	st_ex_file_id;
 	mode_t		st_ex_mode;
 	nlink_t		st_ex_nlink;

--- a/source3/lib/system.c
+++ b/source3/lib/system.c
@@ -306,6 +306,12 @@ void init_stat_ex_from_stat (struct stat_ex *dst,
 #else
 	dst->st_ex_flags = 0;
 #endif
+
+#ifdef HAVE_STAT_ST_GEN
+	dst->st_ex_gen = src->st_gen;
+#else
+	dst->st_ex_gen = 0;
+#endif
 	dst->st_ex_file_id = dst->st_ex_ino;
 	dst->st_ex_iflags |= ST_EX_IFLAG_CALCULATED_FILE_ID;
 }

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -969,9 +969,39 @@ static int ixnas_renameat(vfs_handle_struct *handle,
 	return result;
 }
 
+static struct file_id ixnas_file_id_create(struct vfs_handle_struct *handle,
+					   const SMB_STRUCT_STAT *sbuf)
+{
+	struct file_id key = (struct file_id) {
+		.devid = sbuf->st_ex_dev,
+		.inode = sbuf->st_ex_ino,
+		.extid = sbuf->st_ex_gen,
+	};
+
+	return key;
+}
+
+static inline uint64_t gen_id_comp(uint64_t p) {
+	uint64_t out = (p & UINT32_MAX) ^ (p >> 32);
+	return out;
+};
+
+static uint64_t ixnas_fs_file_id(struct vfs_handle_struct *handle,
+				 const SMB_STRUCT_STAT *psbuf)
+{
+	uint64_t file_id;
+	if (!(psbuf->st_ex_iflags & ST_EX_IFLAG_CALCULATED_FILE_ID)) {
+		return psbuf->st_ex_file_id;
+	}
+
+	file_id = gen_id_comp(psbuf->st_ex_ino);
+	file_id |= gen_id_comp(psbuf->st_ex_gen) << 32;
+	return file_id;
+}
+
 static int fsp_set_times(files_struct *fsp, struct timespec *times, bool set_btime)
 {
-	int flag = set_btime ? AT_UTIMENSAT_FULL : 0;
+	int flag = set_btime ? AT_UTIMENSAT_BTIME : 0;
 	if (fsp->fsp_flags.have_proc_fds) {
 		int fd = fsp_get_pathref_fd(fsp);
 		const char *p = NULL;
@@ -1222,6 +1252,8 @@ static struct vfs_fn_pointers ixnas_fns = {
 	.fchmod_fn = ixnas_fchmod,
 	.fntimes_fn = ixnas_ntimes,
 	.renameat_fn = ixnas_renameat,
+	.file_id_create_fn = ixnas_file_id_create,
+	.fs_file_id_fn = ixnas_fs_file_id,
 	.fget_nt_acl_fn = ixnas_fget_nt_acl,
 	.fset_nt_acl_fn = ixnas_fset_nt_acl,
 	.sys_acl_get_fd_fn = ixnas_fail__sys_acl_get_fd,

--- a/source3/wscript
+++ b/source3/wscript
@@ -317,6 +317,8 @@ int main(int argc, char **argv)
                                 headers='sys/stat.h')
     conf.CHECK_STRUCTURE_MEMBER('struct stat', 'st_flags', define='HAVE_STAT_ST_FLAGS',
                                 headers='sys/types.h sys/stat.h unistd.h')
+    conf.CHECK_STRUCTURE_MEMBER('struct stat', 'st_gen', define='HAVE_STAT_ST_GEN',
+                                headers='sys/types.h sys/stat.h unistd.h')
 
     if conf.env.HAVE_BLKCNT_T:
         conf.CHECK_CODE('''


### PR DESCRIPTION
FreeBSD returns inode generation in stat(2) output. Detect
whether this is present in stat header during wscript and
expand our internal samba stat structure to include it.
Use this to generate file ids in the vfs_ixnas.
