### PR TITLE
Make socket listen backlog configurable on FreeBSD

### DIFF
--- a/lib/tevent/echo_server.c
+++ b/lib/tevent/echo_server.c
@@ -633,7 +633,7 @@ int main(int argc, const char **argv)
 		exit(1);
 	}
 
-	ret = listen(listen_sock, 5);
+	ret = listen(listen_sock, -1);
 	if (ret == -1) {
 		perror("listen() failed");
 		exit(1);

--- a/lib/tevent/echo_server.c
+++ b/lib/tevent/echo_server.c
@@ -633,7 +633,11 @@ int main(int argc, const char **argv)
 		exit(1);
 	}
 
+#if defined (FREEBSD)
 	ret = listen(listen_sock, -1);
+#else
+	ret = listen(listen_sock, 5);
+#endif
 	if (ret == -1) {
 		perror("listen() failed");
 		exit(1);

--- a/source3/include/local.h
+++ b/source3/include/local.h
@@ -163,7 +163,18 @@
 #define WINBIND_SERVER_MUTEX_WAIT_TIME (( ((NUM_CLI_AUTH_CONNECT_RETRIES) * ((CLI_AUTH_TIMEOUT)/1000)) + 5)*2)
 
 /* size of listen() backlog in smbd */
+#if defined (FREEBSD)
+#define SMBD_LISTEN_BACKLOG -1
+#else
 #define SMBD_LISTEN_BACKLOG 50
+#endif
+
+/* size of listen() default backlog */
+#if defined (FREEBSD)
+#define DEFAULT_LISTEN_BACKLOG -1
+#else
+#define DEFAULT_LISTEN_BACKLOG 5
+#endif
 
 /* Number of microseconds to wait before a sharing violation. */
 #define SHARING_VIOLATION_USEC_WAIT 950000

--- a/source3/libsmb/unexpected.c
+++ b/source3/libsmb/unexpected.c
@@ -95,7 +95,7 @@ NTSTATUS nb_packet_server_create(TALLOC_CTX *mem_ctx,
 		status = map_nt_error_from_unix(errno);
 		goto fail;
 	}
-	rc = listen(result->listen_sock, 5);
+	rc = listen(result->listen_sock, DEFAULT_LISTEN_BACKLOG);
 	if (rc < 0) {
 		status = map_nt_error_from_unix(errno);
 		goto fail;

--- a/source3/utils/smbfilter.c
+++ b/source3/utils/smbfilter.c
@@ -291,7 +291,7 @@ static void start_filter(char *desthost)
 		exit(1);
 	}
 
-	if (listen(s, 5) == -1) {
+	if (listen(s, DEFAULT_LISTEN_BACKLOG) == -1) {
 		d_printf("listen failed\n");
 	}
 

--- a/source3/winbindd/winbindd.c
+++ b/source3/winbindd/winbindd.c
@@ -1312,7 +1312,7 @@ static bool winbindd_setup_listeners(void)
 	if (pub_state->fd == -1) {
 		goto failed;
 	}
-	rc = listen(pub_state->fd, 5);
+	rc = listen(pub_state->fd, DEFAULT_LISTEN_BACKLOG);
 	if (rc < 0) {
 		goto failed;
 	}
@@ -1344,7 +1344,7 @@ static bool winbindd_setup_listeners(void)
 	if (priv_state->fd == -1) {
 		goto failed;
 	}
-	rc = listen(priv_state->fd, 5);
+	rc = listen(priv_state->fd, DEFAULT_LISTEN_BACKLOG);
 	if (rc < 0) {
 		goto failed;
 	}


### PR DESCRIPTION
setting this to -1 allows it to be controlled via sysctl.
