### PR TITLE
Make samba aware of ACL brand and trivial ACEs

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -440,6 +440,7 @@ typedef struct files_struct {
 		bool closing : 1;
 		bool lock_failure_seen : 1;
 		bool encryption_required : 1;
+		bool acl_is_trivial : 1;
 	} fsp_flags;
 
 	struct tevent_timer *update_write_time_event;

--- a/source3/modules/nfs41acl.x
+++ b/source3/modules/nfs41acl.x
@@ -93,6 +93,8 @@ const ACL4_XATTR_VERSION_DEFAULT = ACL4_XATTR_VERSION_40;
 const ACL4_AUTO_INHERIT         = 0x00000001;
 const ACL4_PROTECTED            = 0x00000002;
 const ACL4_DEFAULTED            = 0x00000004;
+const ACL4_IS_TRIVIAL           = 0x00010000;
+const ACL4_IS_DIR               = 0x00020000;
 
 typedef u_int aclflag4;
 

--- a/source3/modules/nfs4_acls.c
+++ b/source3/modules/nfs4_acls.c
@@ -49,6 +49,7 @@ struct SMB4ACL_T
 {
 	uint16_t controlflags;
 	uint32_t naces;
+	bool is_trivial;
 	struct SMB4ACE_T	*first;
 	struct SMB4ACE_T	*last;
 };
@@ -264,6 +265,25 @@ bool smbacl4_set_controlflags(struct SMB4ACL_T *acl, uint16_t controlflags)
 	acl->controlflags = controlflags;
 	return true;
 }
+
+bool smbacl4_get_trivial(const struct SMB4ACL_T *acl, bool *trivialp)
+{
+	if (acl == NULL) {
+		return false;
+	}
+	*trivialp = acl->is_trivial;
+	return true;
+}
+
+bool smbacl4_set_trivial(struct SMB4ACL_T *acl, bool trivial)
+{
+	if (acl == NULL) {
+		return false;
+	}
+	acl->is_trivial = trivial;
+	return true;
+}
+
 
 bool nfs_ace_is_inherit(SMB_ACE4PROP_T *ace)
 {

--- a/source3/modules/nfs4_acls.h
+++ b/source3/modules/nfs4_acls.h
@@ -140,6 +140,10 @@ bool smbacl4_set_controlflags(struct SMB4ACL_T *theacl, uint16_t controlflags);
 
 bool nfs_ace_is_inherit(SMB_ACE4PROP_T *ace);
 
+bool smbacl4_get_trivial(const struct SMB4ACL_T *acl, bool *trivialp);
+
+bool smbacl4_set_trivial(struct SMB4ACL_T *acl, bool trivial);
+
 NTSTATUS smb_fget_nt_acl_nfs4(files_struct *fsp,
 	const struct smbacl4_vfs_params *pparams,
 	uint32_t security_info,

--- a/source3/modules/nfs4acl_xattr_xdr.c
+++ b/source3/modules/nfs4acl_xattr_xdr.c
@@ -276,6 +276,8 @@ static NTSTATUS nfs4acl_xdr_blob_to_nfs4acli(struct vfs_handle_struct *handle,
 	return NT_STATUS_OK;
 }
 
+#define ACL4_ALL_FLAGS (ACL4_AUTO_INHERIT | ACL4_PROTECTED | ACL4_DEFAULTED)
+
 static NTSTATUS nfs4acli_to_smb4acl(struct vfs_handle_struct *handle,
 				    TALLOC_CTX *mem_ctx,
 				    nfsacl41i *nacl,
@@ -300,7 +302,8 @@ static NTSTATUS nfs4acli_to_smb4acl(struct vfs_handle_struct *handle,
 	if (config->nfs_version > ACL4_XATTR_VERSION_40) {
 		nfsacl41_flag = nfs4acli_get_flags(nacl);
 		smb4acl_flags = nfs4acl_to_smb4acl_flags(nfsacl41_flag);
-		smbacl4_set_controlflags(smb4acl, smb4acl_flags);
+		smbacl4_set_controlflags(smb4acl, smb4acl_flags & ACL4_ALL_FLAGS);
+		smbacl4_set_trivial(smb4acl, smb4acl_flags & ACL4_IS_TRIVIAL);
 	}
 
 	DBG_DEBUG("flags [%x] nace [%u]\n", smb4acl_flags, naces);


### PR DESCRIPTION
* Add helper functions for generic NFSv4 ACL code in samba to query / set whether an ACL is trivial.
* Expand files_struct to contain this info subsequent to a GET_NT_ACL request
* Add handling to vfs_recycle to determine whether to strip an ACL before applying a recycle mode.