### PR TITLE
s3:modules:vfs_ixnas - fix case-insensitive renames

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+samba (2:4.15.7+ix-0) unstable; urgency=medium
+
+  * Update to Samba 4.15.7
+
+ -- Andrew Walker <awalker@ixsystems.com>  Wed, 27 Apr 2022 17:00:00 +0000
+
+
 samba (2:4.15.5+ix-0) unstable; urgency=medium
 
   * Update to Samba 4.15.5


### PR DESCRIPTION
Changes in samba's VFS broke vfs_ixnas logic for performing
renames on case-insensitive datasets where rename is intended
to change case of file. ZFS case insensitive datasets are
case preserving and so in this situation we need to rename
through an intermediary file in order for renameat() to
succeed. Now that we have guaranteed-unique IDs for
files, append this rather than a jenkins hash.
