### PR TITLE
NAS-115956 / 22.12 / modules - properly clean up temp pathref fsps

### DIFF
--- a/source3/modules/vfs_winmsa.c
+++ b/source3/modules/vfs_winmsa.c
@@ -157,6 +157,7 @@ static NTSTATUS winmsa_inherit_acl(vfs_handle_struct *handle,
 	}
 
 	status = fd_close(tmp_fsp);
+	file_free(NULL, tmp_fsp);
 	return status;
 }
 

--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -393,6 +393,7 @@ static bool zfs_inherit_acls(vfs_handle_struct *handle,
 		}
 
 		fd_close(pathref);
+		file_free(NULL, pathref);
 		pathref = c_fsp;
 	}
 	error = chdir(handle->conn->connectpath);

--- a/source3/smbd/smbXsrv_tcon.c
+++ b/source3/smbd/smbXsrv_tcon.c
@@ -914,7 +914,6 @@ NTSTATUS smbXsrv_tcon_disconnect(struct smbXsrv_tcon *tcon, uint64_t vuid)
 				  tcon->global->share_name,
 				  nt_errstr(status)));
 
-			close_cnum(tcon->compat, vuid);
 			tcon->compat = NULL;
 			return status;
 		}


### PR DESCRIPTION
In certain situations where modules were generating temporary
files structs for at-based syscalls, we weren't fully freeing
all resources related to the temporary file. Ensure we
properly decref files count and adjust fsp list prior to
freeing the temporary fsp.