### PR TITLE
NAS-115689 / s3:zfs_core improve error handling for corrupt pools

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -1418,6 +1418,10 @@ int conn_zfs_init(TALLOC_CTX *mem_ctx,
 	if ((conn_zfsp == NULL) && (strlen(connectpath) > 15)) {
 		DBG_ERR("Failed to obtain zhandle on connectpath: %s\n",
 			strerror(errno));
+		if (errno == EAGAIN) {
+			DBG_ERR("IO has been suspended on ZPOOL.\n");
+			return -1;
+		}
 		tmp_name = strstr(connectpath, "/.zfs/snapshot/");
 		if (tmp_name != NULL) {
 			DBG_INFO("Connectpath is zfs snapshot. Opening zhandle "

--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -595,7 +595,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 			    &lz,
 			    &config->dl,
 			    handle->conn->tcon != NULL);
-	if (ret != 0) {
+	if ((ret != 0) || (config->dl == NULL)) {
 		DBG_ERR("Failed to initialize ZFS data: %s\n",
 			strerror(errno));
 		return ret;


### PR DESCRIPTION
If pool is corrupt, getting dataset handle will fail with
EAGAIN. Make sure this error condition is passed properly back
to caller and log prominently in log.smbd.
