### PR TITLE
NAS-116108 / s3:vfs_recycle - properly clean up tmp fsp on recyclebin failure

### DIFF
--- a/source3/modules/vfs_recycle.c
+++ b/source3/modules/vfs_recycle.c
@@ -899,8 +899,7 @@ static int recycle_chdir(vfs_handle_struct *handle,
 	ok = make_new_bin(handle, config, tmp_dirfsp, handle->conn->connectpath);
 	if (!ok) {
 		DBG_ERR("%s: add to pathrefs failed\n", handle->conn->connectpath);
-		TALLOC_FREE(tmp_dirfsp);
-		return -1;
+		ret = -1;
 	}
 
 	fd_close(tmp_dirfsp);


### PR DESCRIPTION
The temporary file open was not being closed / cleaned up properly
resulting in crash during session teardown.