### PR TITLE
NAS-115478 / s3:vfs_shadow_copy_zfs - ensure that we leave new zhandle open (#95)

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -135,6 +135,7 @@ static int smblibzfs_handle_destructor(struct smblibzfs_int *slibzp)
 		return 0;
 	}
 	libzfs_fini(slibzp->libzfsp);
+	slibzp->libzfsp = NULL;
 	return 0;
 }
 
@@ -146,6 +147,7 @@ static int smbzhandle_destructor(struct smbzhandle_int *szhp)
 		return 0;
 	}
 	zfs_close(szhp->zhandle);
+	szhp->zhandle = NULL;
 	return 0;
 }
 

--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -110,7 +110,7 @@ static struct zfs_dataset *shadow_path_to_dataset(struct dataset_list *dl,
 	 * memory context of our dataset list.
 	 */
 	child = smb_zfs_path_get_dataset(dl->root->zhandle->lz, dl,
-					 path, true, false, true);
+					 path, true, true, true);
 	if (child != NULL) {
 		DLIST_ADD(dl->children, child);
 		return child;


### PR DESCRIPTION
Closing of store ZFS dataset handle will happen in talloc destructor
when associated memory is freed.