### PR TITLE
NAS-116196 / s3:vfs_zfs_core - handle case-insensitive renames

### DIFF
--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -553,6 +553,80 @@ static int zfs_core_chdir(vfs_handle_struct *handle,
 	return SMB_VFS_NEXT_CHDIR(handle, smb_fname);
 }
 
+/*
+ * Windows clients return NT_STATUS_OBJECT_NAME_COLLISION in case of
+ * rename in case of rename in case insensitive dataset. MacOS does
+ * attempts the rename. rename() in FreeBSD in this returns success, but
+ * does not actually rename the file. Add new logic to rename(). If
+ * a case_insensitive string comparison of the filenames returns 0, then
+ * perform two renames so that the returned filename matches client
+ * expectations. First rename appends a unique id generated from
+ * inode and generation number to the file's name. This makes the
+ * rename deterministic, while minimizing risk of name collisions.
+ */
+static int zfs_core_renameat(vfs_handle_struct *handle,
+			     files_struct *srcfsp,
+			     const struct smb_filename *smb_fname_src,
+			     files_struct *dstfsp,
+			     const struct smb_filename *smb_fname_dst)
+{
+	int result = 1;
+	struct zfs_core_config_data *config = NULL;
+	char *tmp_base_name = NULL;
+	uint64_t srcid, dstid;
+
+	SMB_VFS_HANDLE_GET_DATA(handle, config,
+				struct zfs_core_config_data,
+				return -1);
+
+	if (config->dl->root->properties->casesens != SMBZFS_INSENSITIVE) {
+		return SMB_VFS_NEXT_RENAMEAT(handle,
+					     srcfsp,
+					     smb_fname_src,
+					     dstfsp,
+					     smb_fname_dst);
+	}
+
+	srcid = SMB_VFS_FS_FILE_ID(handle->conn, &srcfsp->fsp_name->st);
+	dstid = SMB_VFS_FS_FILE_ID(handle->conn, &dstfsp->fsp_name->st);
+
+	if (srcid == dstid) {
+		result = strcasecmp_m(smb_fname_src->base_name,
+				      smb_fname_dst->base_name);
+	}
+	if (result != 0) {
+		return SMB_VFS_NEXT_RENAMEAT(handle,
+					     srcfsp,
+					     smb_fname_src,
+					     dstfsp,
+					     smb_fname_dst);
+	}
+
+	dstid = SMB_VFS_FS_FILE_ID(handle->conn, &smb_fname_src->st);
+	tmp_base_name = talloc_asprintf(talloc_tos(), "%s_%lu",
+					smb_fname_src->base_name, dstid);
+	if (tmp_base_name == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
+	result = renameat(
+		fsp_get_pathref_fd(srcfsp), smb_fname_src->base_name,
+		fsp_get_pathref_fd(dstfsp), tmp_base_name
+        );
+	if (result != 0) {
+		DBG_ERR("Failed to rename %s to intermediate name %s\n",
+			smb_fname_src->base_name, tmp_base_name);
+		TALLOC_FREE(tmp_base_name);
+		return result;
+	}
+	result = renameat(
+		fsp_get_pathref_fd(dstfsp), tmp_base_name,
+		fsp_get_pathref_fd(srcfsp), smb_fname_dst->base_name
+        );
+	TALLOC_FREE(tmp_base_name);
+	return result;
+}
+
 static int zfs_core_connect(struct vfs_handle_struct *handle,
 			    const char *service, const char *user)
 {
@@ -634,6 +708,7 @@ static struct vfs_fn_pointers zfs_core_fns = {
 	.fs_capabilities_fn = zfs_core_fs_capabilities,
 	.chdir_fn = zfs_core_chdir,
 	.connect_fn = zfs_core_connect,
+	.renameat_fn = zfs_core_renameat,
 	.get_quota_fn = zfs_core_get_quota,
 	.set_quota_fn = zfs_core_set_quota,
 	.disk_free_fn = zfs_core_disk_free


### PR DESCRIPTION
Shift logic for case-insensitive renames from vfs_ixnas to
vfs_zfs_core so that these renames work correctly when
POSIX ACLs are used.
