### PR TITLE
NAS-116200 / nsswitch:pam_winbind - gracefully handle winbind errors

### DIFF
--- a/nsswitch/pam_winbind.c
+++ b/nsswitch/pam_winbind.c
@@ -2709,6 +2709,9 @@ static int openpam_convert_error_code(struct pwb_context *ctx,
 		    r == PAM_CRED_ERR) {
 			return r;
 		}
+		else if (r == PAM_AUTHINFO_UNAVAIL) {
+			return PAM_CRED_UNAVAIL;
+		}
 		break;
 	case PAM_WINBIND_ACCT_MGMT:
 		if (r == PAM_USER_UNKNOWN ||


### PR DESCRIPTION
Convert PAM_AUTHINFO_UNAVAIL to PAM_CRED_UNAVAIL for pam_setcred()
response. Winbindd defaults to PAM_AUTHINFO_UNAVAIL for various errors
pam_winbind attempts to convert these to appropriate openpam responses,
but will default to PAM_SERVICE_ERR.