### PR TITLE
NAS-116207 / s3:recycle - stat the file to be recycled if needed

### DIFF
--- a/source3/modules/vfs_recycle.c
+++ b/source3/modules/vfs_recycle.c
@@ -684,7 +684,10 @@ static int recycle_unlink_internal(vfs_handle_struct *handle,
 	size_t final_name_len;
 	recycle_bin *the_bin = NULL;
 
-	SMB_ASSERT(VALID_STAT(smb_fname->st));
+	if (!VALID_STAT(smb_fname->st)) {
+		SMB_ASSERT(SMB_VFS_STAT(handle->conn, smb_fname) == 0);
+	}
+
 	the_bin = get_recycle_bin(handle, smb_fname);
 	if (the_bin == NULL) {
 		DBG_ERR("Failed to get recycle bin for file\n");


### PR DESCRIPTION
When vfs_fruit recycles resource forks it intentionally omits
stat info. Add check for this in vfs_recycle and attempt to
stat the file being deleted. SMB_ASSERT if stat() fails.
