### PR TITLE
NAS-116728 / s3:modules:recycle - don't assert on failure with ENOENT

### DIFF
--- a/source3/modules/vfs_recycle.c
+++ b/source3/modules/vfs_recycle.c
@@ -685,7 +685,11 @@ static int recycle_unlink_internal(vfs_handle_struct *handle,
 	recycle_bin *the_bin = NULL;
 
 	if (!VALID_STAT(smb_fname->st)) {
-		SMB_ASSERT(SMB_VFS_STAT(handle->conn, smb_fname) == 0);
+		int err = SMB_VFS_STAT(handle->conn, smb_fname);
+		if (err && (errno == ENOENT)) {
+			return err;
+		}
+		SMB_ASSERT(err == 0);
 	}
 
 	the_bin = get_recycle_bin(handle, smb_fname);


### PR DESCRIPTION
There are some cases where client may try to unlink non-existent
adouble files. We can skip the recycle in this case, but keep
assertion in other cases so that we can address any further
unexpected failures.