### PR TITLE
Fix cflags for smb_libzfs

### DIFF
--- a/source3/modules/wscript_build
+++ b/source3/modules/wscript_build
@@ -360,7 +360,7 @@ else:
 
 bld.SAMBA3_LIBRARY('smb_libzfs',
                    source='smb_libzfs.c',
-                   cflags='-DNEED_SOLARIS_BOOLEAN',
+                   cflags_end='-DNEED_SOLARIS_BOOLEAN',
                    deps='samba-util',
                    includes=bld.CONFIG_GET('CPPPATH_ZFS'),
                    ldflags='-luutil -lzfs_core -lzfs -lnvpair',


### PR DESCRIPTION
This fixes a quite old bug in wscript build for libzfs integration
going back to FreeNAS 9.10. We were overwriting the default
cflags rather than appending them when building the library. This
wasn't caught earlier because the build wasn't dependent on them,
but now that we have some FreeBSD-specific code, this resulted
in the wrong version of fget_zhandle to get built and therefore
fail because of different procfd paths.
