### PR TITLE
NAS-117071 / modules:shadow_copy_zfs - fix shadow copies on child ds

### DIFF
--- a/source3/modules/wscript_build
+++ b/source3/modules/wscript_build
@@ -358,9 +358,13 @@ if bld.CONFIG_SET("HAVE_RPC_XDR_H"):
 else:
     bld.SET_TARGET_TYPE('VFS_NFS4_XDR', 'EMPTY')
 
+libzfs_cflags = '-DNEED_SOLARIS_BOOLEAN'
+if bld.CONFIG_SET('FREEBSD'):
+    libzfs_cflags += ' -DFREEBSD'
+
 bld.SAMBA3_LIBRARY('smb_libzfs',
                    source='smb_libzfs.c',
-                   cflags_end='-DNEED_SOLARIS_BOOLEAN',
+                   cflags_end=libzfs_cflags,
                    deps='samba-util',
                    includes=bld.CONFIG_GET('CPPPATH_ZFS'),
                    ldflags='-luutil -lzfs_core -lzfs -lnvpair',


### PR DESCRIPTION
Zero-initialize temporary buffers for paths, Fix check for
stored connectpath mountpoint. Ensure -DFREEBSD when
building on that platform while compiling smb_libzfs.
Simplify arguments being passed into function to resolve
shadow copy paths.