### PR TITLE
Do not map synchronize bit when acemask empty (#145)

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -518,7 +518,8 @@ static bool zfsentry2smbace(zfsacl_entry_t ae, SMB_ACE4PROP_T *aceprop)
 				     SMB_ACE4_DELETE);
 	}
 
-	if (aceprop->aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE) {
+	if ((aceprop->aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE) &&
+	    (aceprop->aceMask != 0)) {
 		aceprop->aceMask |= SMB_ACE4_SYNCHRONIZE;
 	}
 


### PR DESCRIPTION
This regression inadvertantly exposed the ixnas locking ACE.

The hidden locking ACE is to control zfs_acl_chmod() behavior
on datasets with aclmode = passthrough and also is legacy feature
from before I upstreamed changes to ZFS related to the
aforementioned function to bypass the chmod on restricted
aclmode.