### PR TITLE
NAS-117545 / Improve error handling for share path errors

### DIFF
--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -56,6 +56,7 @@ static struct zfs_dataset *smbfname_to_ds(const struct connection_struct *conn,
 	char path[PATH_MAX + 1];
 	int len;
 
+	SMB_ASSERT(config->ds != NULL);
 	if (VALID_STAT(smb_fname->st)) {
 		psbuf = &smb_fname->st;
 	}
@@ -715,6 +716,8 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 			    &config->ds,
 			    handle->conn->tcon != NULL);
 	if (ret != 0 || (config->ds == NULL)) {
+		config->zfs_space_enabled = false;
+		config->zfs_quota_enabled = false;
 		DBG_ERR("Failed to initialize ZFS data: %s\n",
 			strerror(errno));
 		return ret;


### PR DESCRIPTION
Users sometimes have invalid / non-existent paths for
shares. In this case, disable the ZFS-related modules
and allow to fall through to where smbd will refuse session
in chdir_user_and_service().

Fix resolve_legacy() function for getting actual mountpoint
of legacy-mounted datasets. On Linux pars /proc/self/mountinfo, on
FreeBSD get array of statfs structs for mounted filesystems.