### PR TITLE
NAS-117746 / Shift aio_cancel() to tevent_kqueue and add destructor

### DIFF
--- a/lib/tevent/tevent_kqueue.h
+++ b/lib/tevent/tevent_kqueue.h
@@ -25,11 +25,22 @@
 #include <aio.h>
 
 struct tevent_aiocb {
+	const char *location;
+	struct tevent_req *req;
+	struct tevent_context *ev;
 	struct aiocb *iocbp;
 	int saved_errno;
 	int rv;
+	bool completed;
 };
 
-int tevent_add_aio_read(struct tevent_context *ev, struct tevent_aiocb *taiocb);
-int tevent_add_aio_write(struct tevent_context *ev, struct tevent_aiocb *taiocb);
-int tevent_add_aio_fsync(struct tevent_context *ev, struct tevent_aiocb *taiocb);
+#define tevent_add_aio_read(taiocb)\
+        (int)_tevent_add_aio_read(taiocb, __location__)
+
+#define tevent_add_aio_write(taiocb)\
+        (int)_tevent_add_aio_write(taiocb, __location__)
+
+#define tevent_add_aio_fsync(taiocb)\
+        (int)_tevent_add_aio_fsync(taiocb, __location__)
+
+void tevent_aio_cancel(struct tevent_aiocb *taiocb);


### PR DESCRIPTION
Expand our tevent aio event structures to include backpointers
to originating tevent request, the event context, and
include location of caller. Add a destructor for the tevent aio
event so that we attempt to aio_cancel() if for some reason the
tevent request's memory is freed unexpectedly. This also has
added benefit of allowing us to identify the particular aio
event type being returned in kevent() calls. The talloc
heirarchy for data structures is also simplified somewhat, and
we use the tevent aio event is pointed to in kevent udata rather
than the originating tevent request. The removes any potential
for race between destructor and event being triggered. We also
abort() now if we fail to cancel an AIO event (the idea being
that we'll want debugging collateral for these sorts of issues).
