### PR TITLE
NAS-117885 / Shift winbindd_cache.tdb to cachedir

### DIFF
--- a/source3/utils/smbcontrol.c
+++ b/source3/utils/smbcontrol.c
@@ -1119,7 +1119,7 @@ static bool do_winbind_online(struct tevent_context *ev_ctx,
 		return False;
 	}
 
-	db_path = state_path(talloc_tos(), "winbindd_cache.tdb");
+	db_path = cache_path(talloc_tos(), "winbindd_cache.tdb");
 	if (db_path == NULL) {
 		return false;
 	}

--- a/source3/winbindd/winbindd_cache.c
+++ b/source3/winbindd/winbindd_cache.c
@@ -148,7 +148,7 @@ static char *wcache_path(void)
 	 * Data needs to be kept persistent in state directory for
 	 * running with "winbindd offline logon".
 	 */
-	return state_path(talloc_tos(), "winbindd_cache.tdb");
+	return cache_path(talloc_tos(), "winbindd_cache.tdb");
 }
 
 static void winbindd_domain_init_backend(struct winbindd_domain *domain)


### PR DESCRIPTION
We do no use winbind offline logins and so it is safe to move
this to the cacehdir which is located on tmpfs.