### PR TITLE
NAS-117908 / s3:modules:vfs_glusterfs - fix pathref opens

### DIFF
--- a/source3/modules/vfs_glusterfs.c
+++ b/source3/modules/vfs_glusterfs.c
@@ -822,6 +822,17 @@ static int vfs_gluster_openat(struct vfs_handle_struct *handle,
 				 how->flags);
 	}
 
+	/*
+	 * Handle non-posix behavior of glfs regarding open flags.
+	 * in future revision investigate passing O_PATH here
+	 * pathref opens pass flags O_NONBLOCK | O_NOFOLLOW. Retry
+	 * via glfs_opendir if we fail here.
+	 */
+	if ((glfd == NULL) && (errno = EISDIR) &&
+	    (how->flags == O_NONBLOCK | O_NOFOLLOW)) {
+		glfd = glfs_opendir(handle->data, smb_fname->base_name);
+	}
+
 	if (became_root) {
 		unbecome_root();
 	}


### PR DESCRIPTION
glfs_open() will fail with EISDIR if the path is a directory.
This is a minimally-invasive temporary fix until we have
glusterfs version with fix here: gluster/glusterfs#3307