### PR TITLE
NAS-118109 / modules/vfs_ixnas.c - Fix ACLType detection in Linux

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -383,10 +383,11 @@ static int fsp_get_acl_brand(files_struct *fsp)
 	if (rv == -1) {
 		if (errno == ENODATA) {
 			return ACL_BRAND_POSIX;
+		} else if (errno != EOPNOTSUPP) {
+			DBG_ERR("%s: fgetxattr() for %s failed: %s\n",
+				fsp_str_dbg(fsp), ACL_XATTR, strerror(errno));
+			return ACL_BRAND_UNKNOWN;
 		}
-		DBG_ERR("%s: fgetxattr() for %s failed: %s\n",
-			fsp_str_dbg(fsp), ACL_XATTR, strerror(errno));
-		return ACL_BRAND_UNKNOWN;
 	}
 
 	rv = SMB_VFS_FGETXATTR(fsp, ACL4_XATTR, NULL, 0);
@@ -427,10 +428,11 @@ static int path_get_aclbrand(const char *path)
 	if (rv == -1) {
 		if (errno == ENODATA) {
 			return ACL_BRAND_POSIX;
+		} else if (errno != EOPNOTSUPP) {
+			DBG_ERR("%s: getxattr() for %s failed: %s\n",
+				path, ACL_XATTR, strerror(errno));
+			return ACL_BRAND_UNKNOWN;
 		}
-		DBG_ERR("%s: getxattr() for %s failed: %s\n",
-			path, ACL_XATTR, strerror(errno));
-		return ACL_BRAND_UNKNOWN;
 	}
 
 	rv = getxattr(path, ACL4_XATTR, NULL, 0);


### PR DESCRIPTION
If POSIX ACLs aren't supported then attempt to read will fail with EOPNOTSUPP. If we get a different failure then error message should be logged and ACL_BRAND_UNKNOWN returned.