### PR TITLE
Clear python error on initializing domain info

### DIFF
--- a/nsswitch/py_wbclient.c
+++ b/nsswitch/py_wbclient.c
@@ -829,8 +829,11 @@ static int py_wbdomain_init(PyObject *obj,
 
 	/* attempt to pre-populate domain information */
 	tmp_domain_info = wbclient_domain_info(obj, NULL);
-	Py_XDECREF(tmp_domain_info);
+	if (tmp_domain_info == NULL) {
+		PyErr_Clear();
+	}
 
+	Py_XDECREF(tmp_domain_info);
 	return 0;
 }
 


### PR DESCRIPTION
We want to allow init of wbclient.Domain object even if we can't currently resolve domain issues.