### PR TITLE
NAS-118259 / modules:shadow_copy_zfs - various bugfixes and improvements

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -72,6 +72,14 @@ struct mntent
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
 #endif
 
+#ifndef ZFSCTL_INO_ROOT
+#if defined (FREEBSD)
+#define ZFSCTL_INO_ROOT     0x1
+#else
+#define ZFSCTL_INO_ROOT     0x0000FFFFFFFFFFFFULL
+#endif /* OS-specific inode number for ZFS ctldir */
+#endif /* ZFSCTL_INO_ROOT */
+
 typedef struct dataset_entry_internal {
 	struct zfs_dataset *ds;
 } dataset_t;
@@ -393,6 +401,11 @@ static zfs_handle_t *fget_zhandle(libzfs_handle_t *lz, dev_t *dev_id, int fd)
 out:
 	ZFS_UNLOCK();
 	return zfsp;
+}
+
+bool inode_is_ctldir(ino_t ino)
+{
+	return ino == ZFSCTL_INO_ROOT ? true : false;
 }
 
 static zfs_handle_t *get_zhandle_from_smbzhandle(struct smbzhandle *smbzhandle)

--- a/source3/modules/smb_libzfs.h
+++ b/source3/modules/smb_libzfs.h
@@ -370,4 +370,5 @@ int conn_zfs_init(TALLOC_CTX *mem_ctx,
 		  struct zfs_dataset **ppds,
 		  bool has_tcon);
 
+bool inode_is_ctldir(ino_t ino);
 #endif	/* !__SMB_LIBZFS_H */


### PR DESCRIPTION
* Pass __func__ as argument into function to convert smb_filename structs into paths relative to snapshot mountpoints so that log messages can indicate the calling function to assist in bug investigations.

* Add additional check to determine whether our resolved path is in the ZFS ctldir (.zfs). If this is the case, then we can short-circuit snapshot lookup. In ZFS, the ctldir has a unique inode number (though this differs between Linux and FreeBSD).

* Optimize some of the path conversion logic. There was a lot of residual unnecessary complexity here from older samba versions. Remove resulting dead code.