### PR TITLE
NAS-118287 / fix IO stalls and crashes when accessed from MacOS Ventura

### DIFF
--- a/lib/tevent/tevent_kqueue.h
+++ b/lib/tevent/tevent_kqueue.h
@@ -31,16 +31,19 @@ struct tevent_aiocb {
 	struct aiocb *iocbp;
 	int saved_errno;
 	int rv;
-	bool completed;
 };
 
+int _tevent_add_aio_read(struct tevent_aiocb *taiocb, const char *location);
 #define tevent_add_aio_read(taiocb)\
         (int)_tevent_add_aio_read(taiocb, __location__)
 
+int _tevent_add_aio_write(struct tevent_aiocb *taiocb, const char *location);
 #define tevent_add_aio_write(taiocb)\
         (int)_tevent_add_aio_write(taiocb, __location__)
 
+int _tevent_add_aio_fsync(struct tevent_aiocb *taiocb, const char *location);
 #define tevent_add_aio_fsync(taiocb)\
         (int)_tevent_add_aio_fsync(taiocb, __location__)
 
 void tevent_aio_cancel(struct tevent_aiocb *taiocb);
+struct aiocb *tevent_ctx_get_iocb(struct tevent_aiocb *taiocb);

--- a/source3/smbd/smb2_flush.c
+++ b/source3/smbd/smb2_flush.c
@@ -126,6 +126,7 @@ static struct tevent_req *smbd_smb2_flush_send(TALLOC_CTX *mem_ctx,
 	struct tevent_req *subreq;
 	struct smbd_smb2_flush_state *state;
 	struct smb_request *smbreq;
+	bool is_compound = false;
 
 	req = tevent_req_create(mem_ctx, &state,
 				struct smbd_smb2_flush_state);
@@ -186,6 +187,11 @@ static struct tevent_req *smbd_smb2_flush_send(TALLOC_CTX *mem_ctx,
 		 */
 		tevent_req_done(req);
 		return tevent_req_post(req, ev);
+	}
+
+	is_compound = smbd_smb2_is_compound(smb2req);
+	if (is_compound) {
+		smb2_request_set_async_internal(smb2req, true);
 	}
 
 	subreq = SMB_VFS_FSYNC_SEND(state, ev, fsp);

--- a/source3/smbd/smb2_ioctl.c
+++ b/source3/smbd/smb2_ioctl.c
@@ -427,6 +427,7 @@ static struct tevent_req *smbd_smb2_ioctl_send(TALLOC_CTX *mem_ctx,
 	struct tevent_req *req;
 	struct smbd_smb2_ioctl_state *state;
 	struct smb_request *smbreq;
+	bool is_compound = false;
 
 	req = tevent_req_create(mem_ctx, &state,
 				struct smbd_smb2_ioctl_state);
@@ -450,6 +451,11 @@ static struct tevent_req *smbd_smb2_ioctl_send(TALLOC_CTX *mem_ctx,
 		return tevent_req_post(req, ev);
 	}
 	state->smbreq = smbreq;
+
+	is_compound = smbd_smb2_is_compound(smb2req);
+	if (is_compound) {
+		smb2_request_set_async_internal(smb2req, true);
+	}
 
 	switch (in_ctl_code & IOCTL_DEV_TYPE_MASK) {
 	case FSCTL_DFS:


### PR DESCRIPTION
* Ensure that memory for aiocb structs are not touched while AIO is in-flight.
* Create memory pool owned by the kqueue event context for aiocb structs, to avoid constant malloc / free calls.
* Simplify cleanup / cancellation of pending IO by relying on destructor for wrapper struct to check whether an aiocb struct is present (and aio_cancel() it if needed).