### PR TITLE
NAS-118341 / lib/zfsacl - add function to convert ACL to string format

### DIFF
--- a/lib/zfsacl/wscript
+++ b/lib/zfsacl/wscript
@@ -26,7 +26,6 @@ def options(opt):
 
 def configure(conf):
     conf.RECURSE('lib/replace')
-    #conf.RECURSE('lib/talloc')
 
     conf.SAMBA_CHECK_PYTHON()
     conf.SAMBA_CHECK_PYTHON_HEADERS()
@@ -44,6 +43,11 @@ def build(bld):
     else:
         SRC = 'zfsacl_impl_freebsd.c'
 
+    zfsacl_cflags = ''
+    if bld.CONFIG_SET('FREEBSD'):
+        zfsacl_cflags += ' -DFREEBSD'
+        zfsacl_cflags += ' -D_ACL_PRIVATE'
+
     bld.SAMBA_LIBRARY('zfsacl',
                       SRC,
                       enabled= True,
@@ -51,6 +55,7 @@ def build(bld):
                       abi_directory='ABI',
                       abi_match='zfsacl_*',
                       vnum=VERSION,
+                      deps='replace',
                       public_headers=(''),
                       public_headers_install=False,
                       private_library=True)

--- a/lib/zfsacl/zfsacl.h
+++ b/lib/zfsacl/zfsacl.h
@@ -1,5 +1,3 @@
-
-
 #ifndef __ZFSACL_H__
 #define __ZFSACL_H__
 
@@ -41,8 +39,23 @@ struct native_acl {
         zfsacl_brand_t brand;
 };
 
-typedef void *zfsacl_entry_t;
-struct zfsacl;
+#if defined (FREEBSD)
+
+#define zfsacl_entry acl_entry
+#define zfsacl acl_t_struct
+
+#else
+
+struct zfsacl_entry { uint netlong[5]; };
+struct zfsacl {
+        size_t aclbuf_size;
+        zfsacl_brand_t brand;
+        uint *aclbuf;
+};
+
+#endif
+
+typedef struct zfsacl_entry *zfsacl_entry_t;
 typedef struct zfsacl *zfsacl_t;
 
 typedef unsigned int zfsace_flagset_t;
@@ -159,6 +172,15 @@ bool zfsacl_get_aclentry(zfsacl_t _acl, int _idx, zfsacl_entry_t *_pentry);
 bool zfsacl_delete_aclentry(zfsacl_t _acl, int _idx);
 
 
+/**
+ * @brief convert an ACL to text. Returns malloced string.
+ *
+ * @param[in] _acl ZFS ACL
+ * @return pointer to text form the of specified ACLe
+ */
+char *zfsacl_to_text(zfsacl_t _acl);
+
+
 /* ACL entry specific functions */
 bool zfsace_get_permset(zfsacl_entry_t _entry, zfsace_permset_t *_pperm);
 bool zfsace_get_flagset(zfsacl_entry_t _entry, zfsace_flagset_t *_pflags);
@@ -270,32 +292,36 @@ const struct {
 const struct {
 	zfsace_permset_t perm;
 	const char *name;
+	char letter;
 } aceperm2name[] = {
-	{ ZFSACE_READ_DATA, "READ_DATA" },
-	{ ZFSACE_LIST_DIRECTORY, "LIST_DIRECTORY" },
-	{ ZFSACE_WRITE_DATA, "WRITE_DATA" },
-	{ ZFSACE_ADD_FILE, "ADD_FILE" },
-	{ ZFSACE_APPEND_DATA, "APPEND_DATA" },
-	{ ZFSACE_ADD_SUBDIRECTORY, "ADD_SUBDIRECTORY" },
-	{ ZFSACE_READ_NAMED_ATTRS, "READ_NAMED_ATTRS" },
-	{ ZFSACE_WRITE_NAMED_ATTRS, "WRITE_NAMED_ATTRS" },
-	{ ZFSACE_READ_ATTRIBUTES, "READ_ATTRIBUTES" },
-	{ ZFSACE_WRITE_ATTRIBUTES, "WRITE_ATTRIBUTES" },
-	{ ZFSACE_DELETE, "DELETE" },
-	{ ZFSACE_READ_ACL, "READ_ACL" },
-	{ ZFSACE_WRITE_ACL, "WRITE_ACL" },
-	{ ZFSACE_WRITE_OWNER, "WRITE_OWNER" },
-	{ ZFSACE_SYNCHRONIZE, "SYNCHRONIZE" },
+	{ ZFSACE_READ_DATA, "READ_DATA", 'r' },
+	{ ZFSACE_LIST_DIRECTORY, "LIST_DIRECTORY", '\0' },
+	{ ZFSACE_WRITE_DATA, "WRITE_DATA", 'w' },
+	{ ZFSACE_ADD_FILE, "ADD_FILE", '\0' },
+	{ ZFSACE_APPEND_DATA, "APPEND_DATA", 'p' },
+	{ ZFSACE_DELETE, "DELETE", 'd' },
+	{ ZFSACE_DELETE_CHILD, "DELETE_CHILD", 'D' },
+	{ ZFSACE_ADD_SUBDIRECTORY, "ADD_SUBDIRECTORY", '\0' },
+	{ ZFSACE_READ_ATTRIBUTES, "READ_ATTRIBUTES", 'a' },
+	{ ZFSACE_WRITE_ATTRIBUTES, "WRITE_ATTRIBUTES", 'A' },
+	{ ZFSACE_READ_NAMED_ATTRS, "READ_NAMED_ATTRS", 'R' },
+	{ ZFSACE_WRITE_NAMED_ATTRS, "WRITE_NAMED_ATTRS", 'W' },
+	{ ZFSACE_READ_ACL, "READ_ACL", 'c' },
+	{ ZFSACE_WRITE_ACL, "WRITE_ACL", 'C' },
+	{ ZFSACE_WRITE_OWNER, "WRITE_OWNER", 'o' },
+	{ ZFSACE_SYNCHRONIZE, "SYNCHRONIZE", 's' },
 };
 
 const struct {
 	zfsace_flagset_t flag;
 	const char *name;
+	char letter;
 } aceflag2name[] = {
-	{ ZFSACE_FILE_INHERIT, "FILE_INHERIT" },
-	{ ZFSACE_DIRECTORY_INHERIT, "DIRECTORY_INHERIT" },
-	{ ZFSACE_NO_PROPAGATE_INHERIT, "NO_PROPAGATE_INHERIT" },
-	{ ZFSACE_INHERITED_ACE, "INHERITED" },
+	{ ZFSACE_FILE_INHERIT, "FILE_INHERIT", 'f' },
+	{ ZFSACE_DIRECTORY_INHERIT, "DIRECTORY_INHERIT", 'd' },
+	{ ZFSACE_INHERIT_ONLY, "INHERIT_ONLY", 'i' },
+	{ ZFSACE_NO_PROPAGATE_INHERIT, "NO_PROPAGATE_INHERIT", 'n' },
+	{ ZFSACE_INHERITED_ACE, "INHERITED", 'I' },
 };
 
 const struct {

--- a/lib/zfsacl/zfsacl_impl_freebsd.c
+++ b/lib/zfsacl/zfsacl_impl_freebsd.c
@@ -513,3 +513,9 @@ bool zfsacl_is_trivial(zfsacl_t _acl, bool *_trivialp)
 	*_trivialp = (triv == 1) ? true : false;
 	return true;
 }
+
+char *zfsacl_to_text(zfsacl_t _acl)
+{
+	acl_t acl = BSDACL(_acl);
+	return acl_to_text_np(acl, NULL, ACL_TEXT_NUMERIC_IDS);
+}

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -74,6 +74,24 @@ static const struct {
 #define KERN_DOSMODES (UF_READONLY | UF_ARCHIVE | UF_SYSTEM | \
 	UF_HIDDEN | UF_SPARSE | UF_OFFLINE | UF_REPARSE)
 
+static void _dump_acl_info(zfsacl_t theacl, const char *fn)
+{
+	char *acltext = NULL;
+
+	if (!CHECK_DEBUGLVL(DBGLVL_DEBUG)) {
+		return;
+	}
+
+	acltext = zfsacl_to_text(theacl);
+	if (acltext == NULL) {
+		DBG_ERR("zfsacl_to_text() failed: %s\n", strerror(errno));
+		return;
+	}
+
+	DBG_ERR("%s():\n%s\n", fn, acltext);
+	free(acltext);
+}
+#define dump_acl_info(x) _dump_acl_info(x, __func__)
 
 #ifndef FREEBSD
 static int ixnas_pathref_reopen(const files_struct *fsp, int flags)
@@ -693,6 +711,7 @@ static NTSTATUS ixnas_fget_nt_acl(struct vfs_handle_struct *handle,
 
 	to_check = fsp->base_fsp ? fsp->base_fsp : fsp;
 	zfsacl = fsp_get_zfsacl(to_check);
+	dump_acl_info(zfsacl);
 	if (zfsacl == NULL) {
 		if ((errno == EINVAL) &&
 		    (fsp_get_acl_brand(fsp) == ACL_BRAND_POSIX)) {
@@ -836,6 +855,7 @@ static bool ixnas_process_smbacl(vfs_handle_struct *handle,
 		return false;
 	}
 
+	dump_acl_info(zfsacl);
 	if (!fsp_set_zfsacl(fsp, zfsacl)) {
 		DBG_ERR("%s: failed to set acl: %s\n",
 			fsp_str_dbg(fsp), strerror(errno));
@@ -1255,6 +1275,7 @@ static int ixnas_fchmod(vfs_handle_struct *handle,
 			fsp_str_dbg(fsp), strerror(errno));
 		return -1;
 	}
+	dump_acl_info(zacl);
 	ok = zfsacl_is_trivial(zacl, &trivial);
 	if (!ok) {
 		DBG_ERR("zfsacl_is_trivial() failed: %s\n", strerror(errno));
@@ -1279,6 +1300,7 @@ static int ixnas_fchmod(vfs_handle_struct *handle,
 			fsp_str_dbg(fsp));
 		goto failure;
 	}
+	dump_acl_info(new_acl);
 	ok = fsp_set_zfsacl(fsp, new_acl);
 	if (!ok) {
 		DBG_ERR("Failed to set new ACL on %s: %s\n",


### PR DESCRIPTION
Add new API call to to lib/zfsacl and use it in vfs_ixnas when log level is set to DEBUG to print zfsacl_t structs to the log file. Output is same in FreeBSD and Linux (linux side implementing the FreeBSD libc acl_to_text() with same semantics).