### PR TITLE
fix dosmode logging

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -149,12 +149,6 @@ static bool ixnas_set_native_dosmode(struct files_struct *fsp, uint64_t dosmode)
 	int err;
 #if defined (FREEBSD)
 	err = SMB_VFS_FCHFLAGS(fsp, dosmode);
-	if (err) {
-		DBG_WARNING("Setting dosmode failed for %s: %s\n",
-			    fsp_str_dbg(fsp), strerror(errno));
-
-		return false;
-	}
 #else
 	if (!fsp->fsp_flags.is_pathref) {
 		err = ioctl(fsp_get_io_fd(fsp), ZFS_IOC_SETDOSFLAGS, &dosmode);
@@ -170,12 +164,17 @@ static bool ixnas_set_native_dosmode(struct files_struct *fsp, uint64_t dosmode)
 		close(fd);
 	}
 
+#endif /* FREEBSD */
 	if (err) {
-		DBG_WARNING("%s: ioctl to set dosmode failed: %s\n",
-			    fsp_str_dbg(fsp), strerror(errno));
+		if (errno != EPERM) {
+			DBG_WARNING("Setting dosmode failed for %s: %s\n",
+				    fsp_str_dbg(fsp), strerror(errno));
+		} else {
+			DBG_DEBUG("Setting dosmode failed for %s: %s\n",
+				  fsp_str_dbg(fsp), strerror(errno));
+		}
 		return false;
 	}
-#endif /* FREEBSD */
 	return true;
 }
 
@@ -292,8 +291,10 @@ static NTSTATUS ixnas_fset_dos_attributes(struct vfs_handle_struct *handle,
 	}
 
 	ok = ixnas_set_native_dosmode(fsp, flags);
-	if (ok && errno != EPERM) {
+	if (ok) {
 		return NT_STATUS_OK;
+	} else if (errno != EPERM) {
+		return map_nt_error_from_unix(errno);
 	}
 
 	status = smbd_check_access_rights_fsp(handle->conn->cwd_fsp, fsp,

--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -1268,7 +1268,7 @@ static NTSTATUS shadow_copy_zfs_get_real_filename_at(
 		0,
 		&conv_fname);
 	if (!NT_STATUS_IS_OK(status)) {
-		DBG_ERR("%s: failed to create synthetic pathref: %s\",
+		DBG_ERR("%s: failed to create synthetic pathref: %s\n",
 			conv, nt_errstr(status));
 		TALLOC_FREE(conv);
 		return status;


### PR DESCRIPTION
Depending on OS, user may not have privilege to set native DOS mode, depending on ACL and SMB configuration we may wish to override this. Existing code allowed override, but generated excessive log messages.