### PR TITLE
NAS-115559 / Add initial O_RESOLVE_BENEATH implementation for FreeBSD

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -667,6 +667,7 @@ typedef struct files_struct {
  * In any other case use fsp_get_io_fd().
  */
 #define TCON_FLAG_STAT_FAILED		0x01
+#define TCON_FLAG_RESOLVE_BENEATH	0x02
 
 #define FSP_POSIX_FLAGS_OPEN		0x01
 #define FSP_POSIX_FLAGS_RENAME		0x02
@@ -719,6 +720,7 @@ typedef struct connection_struct {
 	/* iXsystems additions */
 	enum acl_brand aclbrand;
 	uint32_t internal_tcon_flags;
+	struct files_struct *connectpath_fsp;
 	/* end iXsystems additions */
 
 	char *connectpath;

--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -702,6 +702,13 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 
 	SMB_ASSERT(!is_named_stream(smb_fname));
 
+#ifdef O_RESOLVE_BENEATH
+	if ((handle->conn->internal_tcon_flags & TCON_FLAG_RESOLVE_BENEATH) &&
+	    !ISDOTDOT(smb_fname->base_name)) {
+		SMB_ASSERT(flags & (O_RESOLVE_BENEATH | O_EMPTY_PATH));
+	}
+#endif
+
 #ifdef O_PATH
 	have_opath = true;
 	if (fsp->fsp_flags.is_pathref) {

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -31,7 +31,7 @@ static int vfs_ixnas_debug_level = DBGC_VFS;
 
 struct ixnas_config_data {
 	struct smbacl4_vfs_params nfs4_params;
-	bool posix_rename;
+	bool use_resolve_beneath;
 	bool dosattrib_xattr;
 	bool zfs_acl_enabled;
 	bool zfs_acl_chmod_enabled;
@@ -1415,6 +1415,97 @@ static int ixnas_ntimes(vfs_handle_struct *handle,
 	}
 	return result;
 }
+
+static bool generate_beneath_path(const char *connectpath,
+				  const struct files_struct *dirfsp,
+				  const struct smb_filename *at_name,
+				  char *buf,
+				  size_t bufsz)
+{
+	if (at_name->base_name[0] == '/') {
+		if (strncmp(connectpath, at_name->base_name, strlen(connectpath)) != 0) {
+			smb_panic("absolute path not within connectpath");
+		}
+		strlcpy(buf, at_name->base_name + strlen(connectpath), bufsz);
+	} else if (ISDOT(dirfsp->fsp_name->base_name)) {
+		strlcpy(buf, at_name->base_name, bufsz);
+	} else if (dirfsp->fsp_name->base_name[0] == '/') {
+		if (strncmp(connectpath, dirfsp->fsp_name->base_name, strlen(connectpath)) != 0) {
+			/*
+			 * vfs_fruit attempts to open paths outside of share root
+			 * any time we chdir to different service
+			 */
+			return false;
+		}
+		if (snprintf(buf, bufsz, "%s/%s",
+			     dirfsp->fsp_name->base_name + strlen(connectpath),
+			     at_name->base_name) >= bufsz) {
+			smb_panic("failed to generate beneath path");
+		}
+	} else {
+		if (snprintf(buf, sizeof(buf), "%s/%s",
+			     dirfsp->fsp_name->base_name,
+			     at_name->base_name) >= bufsz) {
+			smb_panic("failed to generate beneath path");
+		}
+	}
+	if (buf[0] == '/') {
+		memmove(buf, buf+1, bufsz -1);
+	}
+	if (buf[0] == '\0') {
+		strlcpy(buf, ".", bufsz);
+	}
+	return true;
+}
+
+static int ixnas_openat(vfs_handle_struct *handle,
+			const struct files_struct *dirfsp,
+			const struct smb_filename *smb_fname_in,
+			files_struct *fsp,
+			int flags, mode_t mode)
+{
+	struct ixnas_config_data *config = NULL;
+
+	SMB_VFS_HANDLE_GET_DATA(handle, config,
+				struct ixnas_config_data,
+				smb_panic("ixnas_openat(): failed to get config"));
+
+	/*
+	 * O_EMPTY_PATH means that we're re-opening the dirfd using
+	 * and so we don't have to worry about symlinks.
+	 */
+	if (config->use_resolve_beneath &&
+	    ((flags & O_EMPTY_PATH) == 0) &&
+	    (handle->conn->connectpath_fsp != NULL) &&
+	    !ISDOTDOT(smb_fname_in->base_name)) {
+		char full_name[PATH_MAX] = { 0 };
+		struct smb_filename full_fname = {
+			.base_name = full_name,
+			.st = smb_fname_in->st,
+			.twrp = smb_fname_in->twrp,
+			.flags = smb_fname_in->flags
+		};
+
+		if (!generate_beneath_path(handle->conn->connectpath,
+					   dirfsp,
+					   smb_fname_in,
+					   full_name,
+					   sizeof(full_name)- 1)) {
+			return -1;
+		}
+
+		handle->conn->internal_tcon_flags |= TCON_FLAG_RESOLVE_BENEATH;
+		flags |= O_RESOLVE_BENEATH;
+
+		return SMB_VFS_NEXT_OPENAT(handle, handle->conn->connectpath_fsp,
+					   &full_fname, fsp, flags, mode);
+	}
+
+	return SMB_VFS_NEXT_OPENAT(handle,
+				   dirfsp,
+				   smb_fname_in,
+				   fsp, flags, mode);
+}
 #endif /* FREEBSD */
 
 static bool set_acl_parameters(struct vfs_handle_struct *handle,
@@ -1496,8 +1587,8 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 		return ret;
 	}
 
-	config->posix_rename = lp_parm_bool(SNUM(handle->conn),
-			"ixnas", "posix_rename", false);
+	config->use_resolve_beneath = lp_parm_bool(SNUM(handle->conn),
+			"ixnas", "use_resolve_beneath", false);
 
 	/*
 	 * Ensure other alternate methods of mapping dosmodes are disabled.
@@ -1550,6 +1641,7 @@ static struct vfs_fn_pointers ixnas_fns = {
 	/* zfs_acl_enabled = true */
 	.fchmod_fn = ixnas_fchmod,
 #if defined (FREEBSD)
+	.openat_fn = ixnas_openat,
 	.fntimes_fn = ixnas_ntimes,
 	.file_id_create_fn = ixnas_file_id_create,
 	.fs_file_id_fn = ixnas_fs_file_id,

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -359,7 +359,9 @@ static int streams_xattr_openat(struct vfs_handle_struct *handle,
 		return vfs_fake_fd();
 	}
 #endif
-	SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+	if (!(handle->conn->internal_tcon_flags & TCON_FLAG_RESOLVE_BENEATH)) {
+		SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+	}
 	fsp->fsp_flags.have_proc_fds = fsp->conn->have_proc_fds;
 
 	status = streams_xattr_get_name(handle, talloc_tos(),

--- a/source3/smbd/filename.c
+++ b/source3/smbd/filename.c
@@ -1393,7 +1393,8 @@ static NTSTATUS check_name(connection_struct *conn,
 		return status;
 	}
 
-	if (!lp_widelinks(SNUM(conn)) || !lp_follow_symlinks(SNUM(conn))) {
+	if (!(conn->internal_tcon_flags & TCON_FLAG_RESOLVE_BENEATH)
+	    && (!lp_widelinks(SNUM(conn)) || !lp_follow_symlinks(SNUM(conn)))) {
 		status = check_reduced_name(conn, NULL, smb_fname);
 		if (!NT_STATUS_IS_OK(status)) {
 			DEBUG(5,("check_name: name %s failed with %s\n",

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -674,7 +674,8 @@ static NTSTATUS non_widelink_open(const struct files_struct *dirfsp,
 	have_opath = true;
 #endif
 
-	if (dirfsp == conn->cwd_fsp) {
+	if ((!(conn->internal_tcon_flags & TCON_FLAG_RESOLVE_BENEATH) || is_named_stream(smb_fname))
+	     && dirfsp == conn->cwd_fsp) {
 		if (fsp->fsp_flags.is_directory) {
 			parent_dir_fname = cp_smb_filename(talloc_tos(), smb_fname);
 			if (parent_dir_fname == NULL) {


### PR DESCRIPTION
Opening files with O_RESOLVE_BENEATH flag protects against symlink escapes from share path. In this case potentially expensive check_reduced_name() calls can be avoided in favor of relying on kernel to ensure safety. To achieve this we do an O_PATH open of the share's connect path during initial chdir(), and then make all subsequent open calls relative to this fd.