### PR TITLE
lib/sunacl - Fix setacl in linux libsunacl

### DIFF
--- a/lib/sunacl/libsunacl.c
+++ b/lib/sunacl/libsunacl.c
@@ -107,19 +107,19 @@ acl_from_aces(zfsacl_t aclp, const ace_t *aces, int nentries)
 			abort();
 		}
 
-		ok = zfsace_set_permset(aclp, permset);
+		ok = zfsace_set_permset(entry, permset);
 		if (!ok) {
 			return (errno);
 		}
-		ok = zfsace_set_flagset(aclp, flagset);
+		ok = zfsace_set_flagset(entry, flagset);
 		if (!ok) {
 			return (errno);
 		}
-		ok = zfsace_set_who(aclp, whotype, whoid);
+		ok = zfsace_set_who(entry, whotype, whoid);
 		if (!ok) {
 			return (errno);
 		}
-		ok = zfsace_set_entry_type(aclp, entry_type);
+		ok = zfsace_set_entry_type(entry, entry_type);
 		if (!ok) {
 			return (errno);
 		}


### PR DESCRIPTION
lib/sunacl is a wrapper for Linux that provides the solaris acl() / facl() API for NFSv4 ACLs. The
primary consumer is vfs_zfacl in Samba, which is
is implemented as a compatibility option for users who have hard-coded vfs_zfacl in the TrueNAS
configuration.