### PR TITLE
NAS-118860 / Preserve timewarp token during symlink safety checks (#194)

### DIFF
--- a/source3/smbd/filename.c
+++ b/source3/smbd/filename.c
@@ -1142,7 +1142,7 @@ static NTSTATUS filename_convert_dirfsp_nosymlink(
 			".",
 			NULL,
 			NULL,
-			0,
+			twrp,
 			posix ? SMB_FILENAME_POSIX_PATH : 0,
 			&smb_dirname);
 	} else {
@@ -1153,7 +1153,7 @@ static NTSTATUS filename_convert_dirfsp_nosymlink(
 			mem_ctx,
 			conn,
 			dirname,
-			0,
+			twrp,
 			&smb_dirname,
 			&unparsed,
 			&substitute);


### PR DESCRIPTION
Timewarp token was being stripped when generating dirfsp, this causes SMB2 CREATE on non-existing previous versions to fail with ENOENT.