### PR TITLE
NAS-118903 / Do not assert on chdir("/") during session teardown

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+samba (2:4.17.2+ix-1) unstable; urgency=medium
+
+ * Fix SMB_ASSERT in vfs_recycle chdir to /
+
+ * Fix symlink safety checks where timewarp token present
+
+ -- Andrew Walker <awalker@ixsystems.com>  Wed, 09 Nov 2022 17:00:00 +0000
+
+
 samba (2:4.17.2+ix-0) unstable; urgency=medium
 
   * Update to Samba 4.17.2

--- a/source3/modules/vfs_recycle.c
+++ b/source3/modules/vfs_recycle.c
@@ -954,7 +954,9 @@ static int recycle_chdir(vfs_handle_struct *handle,
 				return -1);
 
 	ret = SMB_VFS_NEXT_CHDIR(handle, smb_fname);
-	if (ret == -1 || config->bins[0] != NULL) {
+	if ((ret == -1) ||
+	    (config->bins[0] != NULL) ||
+	    (strcmp(smb_fname->base_name, "/") == 0)) {
 		return ret;
 	}
 


### PR DESCRIPTION
If session setup fails due to lack of permissions to share path, samba will still attempt to chdir("/") on session teardown. We shouldn't assert in vfs_recycle in this case.