### PR TITLE
Do not assert on chdir("/") during session teardown

### DIFF
--- a/source3/modules/vfs_recycle.c
+++ b/source3/modules/vfs_recycle.c
@@ -887,7 +887,9 @@ static int recycle_chdir(vfs_handle_struct *handle,
 				return -1);
 
 	ret = SMB_VFS_NEXT_CHDIR(handle, smb_fname);
-	if (ret == -1 || config->bins[0] != NULL) {
+	if ((ret == -1) ||
+	    (config->bins[0] != NULL) ||
+	    (strcmp(smb_fname->base_name, "/") == 0)) {
 		return ret;
 	}
 


### PR DESCRIPTION
If session setup fails due to lack of permissions to share path, samba will still attempt to chdir("/") on session teardown. We shouldn't assert in vfs_recycle in this case.