### PR TITLE
NAS-118926 / Perform fsctl ops on base FSP in streams_xattr

### DIFF
--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -1660,7 +1660,7 @@ static NTSTATUS streams_xattr_fsctl(struct vfs_handle_struct *handle,
 
 	if (fsp->base_fsp != NULL) {
 		target = fsp->base_fsp;
-		DBG_INFO("Passing FSCTL 0x%08x on stream %s  to base file %s\",
+		DBG_INFO("Passing FSCTL 0x%08x on stream %s  to base file %s\n",
 			 function, fsp->fsp_name->stream_name, fsp_str_dbg(fsp->base_fsp));
 	} else {
 		target = fsp;

--- a/source4/torture/smb2/ioctl.c
+++ b/source4/torture/smb2/ioctl.c
@@ -3838,6 +3838,100 @@ static bool test_ioctl_sparse_qar_malformed(struct torture_context *torture,
 	return true;
 }
 
+static NTSTATUS test_ioctl_stream(struct torture_context *torture,
+			       TALLOC_CTX *mem_ctx,
+			       struct smb2_tree *tree,
+			       struct smb2_handle fh)
+{
+	union smb_ioctl ioctl;
+	NTSTATUS status;
+	struct file_zero_data_info zdata_info;
+	TALLOC_CTX *tmp_ctx = talloc_new(mem_ctx);
+	if (tmp_ctx == NULL) {
+		return NT_STATUS_NO_MEMORY;
+	}
+
+	ZERO_STRUCT(ioctl);
+	ioctl.smb2.level = RAW_IOCTL_SMB2;
+	ioctl.smb2.in.file.handle = fh;
+	ioctl.smb2.in.function = FSCTL_CREATE_OR_GET_OBJECT_ID,
+	ioctl.smb2.in.max_output_response = 64;
+	ioctl.smb2.in.flags = SMB2_IOCTL_FLAG_IS_FSCTL;
+
+	status = smb2_ioctl(tree, tmp_ctx, &ioctl.smb2);
+	if (!NT_STATUS_IS_OK(status)) {
+		goto err_out;
+	}
+
+	status = NT_STATUS_OK;
+err_out:
+	talloc_free(tmp_ctx);
+	return status;
+}
+
+bool test_ioctl_alternate_data_stream(struct torture_context *tctx)
+{
+	bool ret = true;
+	int offset, beyond_final_zero;
+	const char *fname = DNAME "\\test_stream_ioctl_dir";
+	const char *sname = DNAME "\\test_stream_ioctl_dir:stream";
+	NTSTATUS status;
+	struct smb2_create create = { };
+	struct smb2_tree *tree = NULL;
+	struct smb2_handle h1 = {{0}};
+	const char *data = "test data";
+
+	if (!torture_smb2_connection(tctx, &tree)) {
+		torture_comment(tctx, "Initializing smb2 connection failed.\n");
+		return false;
+	}
+
+	smb2_deltree(tree, DNAME);
+
+	status = torture_smb2_testdir(tree, DNAME, &h1);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+					"torture_smb2_testdir failed\n");
+
+	smb2_util_close(tree, h1);
+	create = (struct smb2_create) {
+		.in.desired_access = SEC_FILE_ALL,
+		.in.share_access = NTCREATEX_SHARE_ACCESS_MASK,
+		.in.file_attributes = FILE_ATTRIBUTE_HIDDEN,
+		.in.create_disposition = NTCREATEX_DISP_CREATE,
+		.in.impersonation_level = SMB2_IMPERSONATION_IMPERSONATION,
+		.in.fname = fname,
+	};
+
+	status = smb2_create(tree, tctx, &create);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+					"smb2_create failed\n");
+
+	h1 = create.out.file.handle;
+	status = smb2_util_close(tree, h1);
+
+	create = (struct smb2_create) {
+		.in.desired_access = SEC_FILE_ALL,
+		.in.share_access = NTCREATEX_SHARE_ACCESS_MASK,
+		.in.file_attributes = FILE_ATTRIBUTE_NORMAL,
+		.in.create_disposition = NTCREATEX_DISP_CREATE,
+		.in.impersonation_level = SMB2_IMPERSONATION_IMPERSONATION,
+		.in.fname = sname,
+	};
+	status = smb2_create(tree, tctx, &create);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+					"smb2_create failed\n");
+        h1 = create.out.file.handle;
+
+	status = test_ioctl_stream(tctx, tctx, tree, h1);
+	if (!NT_STATUS_IS_OK(status)) {
+		smb2_util_close(tree, h1);
+		torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+						"test_ioctl_stream failed\n");
+	}
+done:
+	return ret;
+}
+
 /*
  * 2.3.57 FSCTL_SET_ZERO_DATA Request
  *

--- a/source4/torture/smb2/smb2.c
+++ b/source4/torture/smb2/smb2.c
@@ -182,6 +182,8 @@ NTSTATUS torture_smb2_init(TALLOC_CTX *ctx)
 				      test_ioctl_set_sparse);
 	torture_suite_add_simple_test(suite, "zero-data-ioctl",
 				      test_ioctl_zero_data);
+	torture_suite_add_simple_test(suite, "ioctl-on-stream",
+				      test_ioctl_alternate_data_stream);
 	torture_suite_add_suite(suite, torture_smb2_rename_init(suite));
 	torture_suite_add_suite(suite, torture_smb2_sharemode_init(suite));
 	torture_suite_add_1smb2_test(suite, "hold-oplock", test_smb2_hold_oplock);


### PR DESCRIPTION
We can add special handling here as-needed for ops on alternate data streams, but for now we can simply do them on the base file.