### PR TITLE
NAS-118949 / pywbclient - Fix refcounting on PyUidGid class init error path

### DIFF
--- a/nsswitch/py_wbclient.c
+++ b/nsswitch/py_wbclient.c
@@ -289,12 +289,11 @@ static int py_uid_gid_init(PyObject *obj,
 	self->id = id;
 
 	self->wbclient = (py_wbclient *)pyclient;
+	Py_INCREF(self->wbclient);
 
 	if (!parse_sid_info(self)) {
 		return -1;
 	}
-
-	Py_INCREF(self->wbclient);
 
 	return 0;
 }


### PR DESCRIPTION
If SID fails to initialize when converting user-provided SID to internal uidgid object, refcount gets off leading to crash.