### PR TITLE
NAS-118951 / shadow_copy_zfs - don't assert if user has MIXED case sensitivity 

### DIFF
--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -214,6 +214,7 @@ char *get_snapshot_path(TALLOC_CTX *mem_ctx,
 	int (*strncmp_fn)(const char *s1, const char *s2, size_t len);
 
 	switch(sens) {
+	case SMBZFS_MIXED:
 	case SMBZFS_SENSITIVE:
 		strcmp_fn = strcmp;
 		strncmp_fn = strncmp;


### PR DESCRIPTION
For non-solaris use-case there's no difference between MIXED and CASESENSITIVE.