### PR TITLE
NAS-119028 / Add SMB VFS hook for reopen_from_fsp for glusterfs pathref handling

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -1241,6 +1241,15 @@ struct vfs_fn_pointers {
 				struct vfs_aio_state *aio_state,
 				uint32_t *dosmode);
 
+	NTSTATUS (*reopen_from_fsp_fn)(
+				struct vfs_handle_struct *handle,
+				struct files_struct *dirfsp,
+				struct smb_filename *smb_fname,
+				struct files_struct *fsp,
+				int flags,
+				mode_t mode,
+				bool *p_file_created);
+
 	/* NT ACL operations. */
 
 	NTSTATUS (*fget_nt_acl_fn)(struct vfs_handle_struct *handle,
@@ -1834,6 +1843,13 @@ NTSTATUS smb_vfs_call_freaddir_attr(struct vfs_handle_struct *handle,
 				    struct files_struct *fsp,
 				    TALLOC_CTX *mem_ctx,
 				    struct readdir_attr_data **attr_data);
+NTSTATUS smb_vfs_call_reopen_from_fsp(struct vfs_handle_struct *handle,
+				      struct files_struct *dirfsp,
+				      struct smb_filename *smb_fname,
+				      struct files_struct *fsp,
+				      int flags,
+				      mode_t mode,
+				      bool *p_file_created);
 
 NTSTATUS smb_register_vfs(int version, const char *name,
 			  const struct vfs_fn_pointers *fns);

--- a/source3/include/vfs_macros.h
+++ b/source3/include/vfs_macros.h
@@ -569,6 +569,13 @@
 #define SMB_VFS_NEXT_AIO_FORCE(handle,fsp) \
 	smb_vfs_call_aio_force((handle)->next,(fsp))
 
+#define SMB_VFS_REOPEN_FROM_FSP(dir, smb_fname, fsp_out, flags, mode, p_created) \
+	smb_vfs_call_reopen_from_fsp((dir)->conn->vfs_handles, (dir), (smb_fname), \
+				     (fsp_out), (flags), (mode), (p_created))
+#define SMB_VFS_NEXT_REOPEN_FROM_FSP(handle, dir, smb_fname, fsp_out, flags, mode, p_created) \
+	smb_vfs_call_reopen_from_fsp((handle)->next, (dir), (smb_fname), \
+				     (fsp_out), (flags), (mode), (p_created))
+
 /* durable handle operations */
 
 #define SMB_VFS_DURABLE_COOKIE(fsp, mem_ctx, cookie) \

--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -4048,6 +4048,18 @@ static NTSTATUS vfswrap_durable_reconnect(struct vfs_handle_struct *handle,
 					     fsp, new_cookie);
 }
 
+static NTSTATUS vfswrap_reopen_from_fsp(struct vfs_handle_struct *handle,
+					struct files_struct *dirfsp,
+					struct smb_filename *smb_fname,
+					struct files_struct *fsp,
+					int flags,
+					mode_t mode,
+					bool *p_file_created)
+{
+	return reopen_from_fsp_default(dirfsp, smb_fname, fsp, flags,
+				       mode, p_file_created);
+}
+
 static struct vfs_fn_pointers vfs_default_fns = {
 	/* Disk operations */
 
@@ -4140,6 +4152,7 @@ static struct vfs_fn_pointers vfs_default_fns = {
 	.offload_write_recv_fn = vfswrap_offload_write_recv,
 	.fget_compression_fn = vfswrap_fget_compression,
 	.set_compression_fn = vfswrap_set_compression,
+	.reopen_from_fsp_fn = vfswrap_reopen_from_fsp,
 
 	/* NT ACL operations. */
 

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -1297,12 +1297,12 @@ static NTSTATUS reopen_from_procfd(struct files_struct *fsp,
 	return NT_STATUS_OK;
 }
 
-static NTSTATUS reopen_from_fsp(struct files_struct *dirfsp,
-				struct smb_filename *smb_fname,
-				struct files_struct *fsp,
-				int flags,
-				mode_t mode,
-				bool *p_file_created)
+NTSTATUS reopen_from_fsp_default(struct files_struct *dirfsp,
+				 struct smb_filename *smb_fname,
+				 struct files_struct *fsp,
+				 int flags,
+				 mode_t mode,
+				 bool *p_file_created)
 {
 	bool __unused_file_created = false;
 	NTSTATUS status;
@@ -1531,7 +1531,8 @@ static NTSTATUS open_file(struct smb_request *req,
 		 * Actually do the open - if O_TRUNC is needed handle it
 		 * below under the share mode lock.
 		 */
-		status = reopen_from_fsp(dirfsp,
+		status = SMB_VFS_REOPEN_FROM_FSP(
+					 dirfsp,
 					 smb_fname_atname,
 					 fsp,
 					 local_flags & ~O_TRUNC,
@@ -4716,7 +4717,7 @@ static NTSTATUS open_directory(connection_struct *conn,
 		FILE_ADD_SUBDIRECTORY;
 
 	if (access_mask & need_fd_access) {
-		status = reopen_from_fsp(
+		status = SMB_VFS_REOPEN_FROM_FSP(
 			fsp->conn->cwd_fsp,
 			fsp->fsp_name,
 			fsp,

--- a/source3/smbd/proto.h
+++ b/source3/smbd/proto.h
@@ -762,6 +762,12 @@ NTSTATUS create_file_default(connection_struct *conn,
 			     int *pinfo,
 			     const struct smb2_create_blobs *in_context_blobs,
 			     struct smb2_create_blobs *out_context_blobs);
+NTSTATUS reopen_from_fsp_default(struct files_struct *dirfsp,
+				 struct smb_filename *smb_fname,
+				 struct files_struct *fsp,
+				 int flags,
+				 mode_t mode,
+				 bool *p_file_created);
 
 /* The following definitions come from smbd/oplock.c  */
 

--- a/source3/smbd/vfs.c
+++ b/source3/smbd/vfs.c
@@ -2847,3 +2847,21 @@ NTSTATUS smb_vfs_call_freaddir_attr(struct vfs_handle_struct *handle,
 					     mem_ctx,
 					     attr_data);
 }
+
+NTSTATUS smb_vfs_call_reopen_from_fsp(struct vfs_handle_struct *handle,
+				      struct files_struct *dirfsp,
+				      struct smb_filename *smb_fname,
+				      struct files_struct *fsp,
+				      int flags,
+				      mode_t mode,
+				      bool *p_file_created)
+{
+	VFS_FIND(reopen_from_fsp);
+	return handle->fns->reopen_from_fsp_fn(handle,
+					       dirfsp,
+					       smb_fname,
+					       fsp,
+					       flags,
+					       mode,
+					       p_file_created);
+}


### PR DESCRIPTION
Pathref FSP to IO FSP conversion can't go through procfs because there fd associatd with FSP is not valid (glfs_fd is an fsp extension). This is preliminary step to adding custom pathref handling for glusterfs.