### PR TITLE
NAS-119314 / nss_winbind - Do not resolve root / admin ids

### DIFF
--- a/nsswitch/winbind_nss_linux.c
+++ b/nsswitch/winbind_nss_linux.c
@@ -538,6 +538,9 @@ _nss_winbind_getpwuid_r(uid_t uid, struct passwd *result, char *buffer,
 #ifdef DEBUG_NSS
 	fprintf(stderr, "[%5d]: getpwuid_r %d\n", getpid(), (unsigned int)uid);
 #endif
+	if ((uid == ROOT_ID) || (uid == TRUENAS_ADMIN_ID)) {
+		return NSS_STATUS_NOTFOUND;
+	}
 
 #ifdef HAVE_PTHREAD
 	pthread_mutex_lock(&winbind_nss_mutex);
@@ -618,6 +621,10 @@ _nss_winbind_getpwnam_r(const char *name, struct passwd *result, char *buffer,
 	fprintf(stderr, "[%5d]: getpwnam_r %s\n", getpid(), name);
 #endif
 
+	if ((strcmp(name, ROOT_USER) == 0) ||
+	    (strcmp(name, TRUENAS_ADMIN_NAME) == 0)) {
+		return NSS_STATUS_NOTFOUND;
+	}
 #ifdef HAVE_PTHREAD
 	pthread_mutex_lock(&winbind_nss_mutex);
 #endif
@@ -903,6 +910,11 @@ _nss_winbind_getgrnam_r(const char *name,
 	fprintf(stderr, "[%5d]: getgrnam %s\n", getpid(), name);
 #endif
 
+	if ((strcmp(name, ROOT_GROUP) == 0) ||
+	    (strcmp(name, TRUENAS_ADMIN_NAME) == 0)) {
+		return NSS_STATUS_NOTFOUND;
+	}
+
 #ifdef HAVE_PTHREAD
 	pthread_mutex_lock(&winbind_nss_mutex);
 #endif
@@ -991,6 +1003,10 @@ _nss_winbind_getgrgid_r(gid_t gid,
 	fprintf(stderr, "[%5d]: getgrgid %d\n", getpid(), gid);
 #endif
 
+	if ((gid == ROOT_ID) || (gid == TRUENAS_ADMIN_ID)) {
+		return NSS_STATUS_NOTFOUND;
+	}
+
 #ifdef HAVE_PTHREAD
 	pthread_mutex_lock(&winbind_nss_mutex);
 #endif
@@ -1072,6 +1088,11 @@ _nss_winbind_initgroups_dyn(const char *user, gid_t group, long int *start,
 	struct winbindd_request request;
 	struct winbindd_response response;
 	int i;
+
+	if ((strcmp(user, ROOT_USER) == 0) ||
+	    (strcmp(user, TRUENAS_ADMIN_NAME) == 0)) {
+		return NSS_STATUS_NOTFOUND;
+	}
 
 #ifdef DEBUG_NSS
 	fprintf(stderr, "[%5d]: initgroups %s (%d)\n", getpid(),

--- a/nsswitch/winbind_nss_linux.h
+++ b/nsswitch/winbind_nss_linux.h
@@ -31,6 +31,13 @@
 #define _PUBLIC_ON_LINUX_ _PRIVATE_
 #endif
 
+#define ROOT_USER "root"
+#define ROOT_GROUP "root"
+#define ROOT_ID 0
+
+#define TRUENAS_ADMIN_NAME "admin"
+#define TRUENAS_ADMIN_ID 950
+
 NSS_STATUS _nss_winbind_setpwent(void);
 NSS_STATUS _nss_winbind_endpwent(void);
 NSS_STATUS _nss_winbind_getpwent_r(struct passwd *result, char *buffer,

--- a/source3/utils/smbcontrol.c
+++ b/source3/utils/smbcontrol.c
@@ -1157,7 +1157,7 @@ static bool do_winbind_offline(struct tevent_context *ev_ctx,
 		return False;
 	}
 
-	db_path = state_path(talloc_tos(), "winbindd_cache.tdb");
+	db_path = cache_path(talloc_tos(), "winbindd_cache.tdb");
 	if (db_path == NULL) {
 		return false;
 	}


### PR DESCRIPTION
There is no reason for these ids to pass through nss_winbind and skipping allows us potentially avoid blocking on the global winbind mutex.

This PR also fixes some missed spots where we didn't change state_path() -> cache_path() for the winbindd_cache.tdb file.