### PR TITLE
NAS-119174 / s3:params:lp_do_section - protect against NULL deref

### DIFF
--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -2892,7 +2892,7 @@ bool lp_do_section(const char *pszSectionName, void *userdata)
 	/* if we have a current service, tidy it up before moving on */
 	bRetval = true;
 
-	if (iServiceIndex >= 0)
+	if ((iServiceIndex >= 0) && (ServicePtrs[iServiceIndex] != NULL))
 		bRetval = lpcfg_service_ok(ServicePtrs[iServiceIndex]);
 
 	/* if all is still well, move to the next record in the services array */

--- a/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
+++ b/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
@@ -657,7 +657,9 @@ static WERROR init_srv_share_info_ctr(struct pipes_struct *p,
 	 *
 	 *  include = /etc/samba/%U.conf
 	 */
-	reload_services(NULL, NULL, false);
+	if (!lp_registry_shares()) {
+		reload_services(NULL, NULL, false);
+	}
 
 	num_services = lp_numservices();
 


### PR DESCRIPTION
iServiceIndex may indicate an empty slot in the ServicePtrs array. In this case, lpcfg_serivce_ok(ServicePtrs[iServiceIndex]) may trigger a NULL deref and crash. Skipping the check here will cause a scan of the array in add_a_service() and the NULL slot will be used safely.