### PR TITLE
NAS-119609 / lib/replace - add extra check to bsd_attr_list

### DIFF
--- a/lib/replace/xattr.c
+++ b/lib/replace/xattr.c
@@ -266,6 +266,18 @@ static ssize_t bsd_attr_list (int type, extattr_arg arg, char *list, size_t size
 
 		for(i = 0; i < list_size; i += len + 1) {
 			len = buf[i];
+
+			/*
+			 * If for some reason we receive a truncated
+			 * return from call to list xattrs the pascal
+			 * string lengths will not be changed and
+			 * therefore we must check that we're not
+			 * reading garbage data or off end of array
+			 */
+			if (len + i >= list_size) {
+				errno = ERANGE;
+				return -1;
+			}
 			strncpy(list, extattr[t].name, extattr[t].len + 1);
 			list += extattr[t].len;
 			strncpy(list, buf + i + 1, len);


### PR DESCRIPTION
The FreeBSD extattr API may return success and truncated namelist. We need to check for this in bsd_attr_list to ensure that we don't accidentally read off the end of the buffer. In the case of a truncated value, the pascal strings for attr names will reflect the lengths as if the value were not truncated. For example:
`58DosStrea`

In case of short read we now set error to ERANGE and fail.