### PR TITLE
s3:smbd:service - add flag inidcating early stat

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -668,6 +668,7 @@ typedef struct files_struct {
  */
 #define TCON_FLAG_STAT_FAILED		0x01
 #define TCON_FLAG_RESOLVE_BENEATH	0x02
+#define TCON_FLAG_INIT_STAT		0x04
 
 #define FSP_POSIX_FLAGS_OPEN		0x01
 #define FSP_POSIX_FLAGS_RENAME		0x02

--- a/source3/modules/vfs_fruit.c
+++ b/source3/modules/vfs_fruit.c
@@ -3285,7 +3285,9 @@ static int fruit_stat(vfs_handle_struct *handle,
 
 	if (!is_named_stream(smb_fname)) {
 		rc = SMB_VFS_NEXT_STAT(handle, smb_fname);
-		if (rc == 0) {
+		// We may be in early validation of share path
+		if ((rc == 0) &&
+		    (handle->conn->internal_tcon_flags & TCON_FLAG_INIT_STAT)) {
 			update_btime(handle, smb_fname);
 		}
 		return rc;

--- a/source3/smbd/service.c
+++ b/source3/smbd/service.c
@@ -824,6 +824,9 @@ static NTSTATUS make_connection_snum(struct smbXsrv_connection *xconn,
 		conn->internal_tcon_flags |= TCON_FLAG_STAT_FAILED;
 	}
 
+	conn->internal_tcon_flags |= TCON_FLAG_INIT_STAT;
+
+
 #ifdef WITH_FAKE_KASERVER
 	if (lp_afs_share(snum)) {
 		afs_login(conn);


### PR DESCRIPTION
Some modules (e.g. vfs_fruit) may try to write to
a share while performing VFS_STAT() on a file.

We don't want to do this before share connection
is fully initialized and so set flag that allows
us to skip this step.