### PR TITLE
s3:modules:fruit - skip btime update if not initialized

### DIFF
--- a/source3/modules/vfs_fruit.c
+++ b/source3/modules/vfs_fruit.c
@@ -3417,7 +3417,10 @@ static int fruit_stat(vfs_handle_struct *handle,
 
 	if (!is_named_stream(smb_fname)) {
 		rc = SMB_VFS_NEXT_STAT(handle, smb_fname);
-		if (rc == 0) {
+		// base_share_dev will be zero if we haven't
+		// fully initialized share
+		if ((rc == 0) &&
+		    (handle->conn->base_share_dev != 0)) {
 			update_btime(handle, smb_fname);
 		}
 		return rc;

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -128,7 +128,7 @@ static bool ixnas_get_native_dosmode(struct files_struct *fsp, uint64_t *_dosmod
 		int fd;
 
 		fd = ixnas_pathref_reopen(fsp, O_RDONLY);
-		if ((fd == -1) && (errno == EPERM)) {
+		if ((fd == -1) && ((errno == EACCES) || (errno == EPERM))) {
 			become_root();
 			fd = ixnas_pathref_reopen(fsp, O_RDONLY);
 			unbecome_root();

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -668,7 +668,11 @@ static NTSTATUS process_symlink_open(const struct files_struct *dirfsp,
 	if (oldwd_fname != NULL) {
 		int ret = vfs_ChDir(conn, oldwd_fname);
 		if (ret == -1) {
-			smb_panic("unable to get back to old directory\n");
+			if (conn->base_share_dev != 0) {
+				smb_panic("unable to get back to old directory\n");
+			} else {
+				status = map_nt_error_from_unix(errno);
+			}
 		}
 		TALLOC_FREE(oldwd_fname);
 	}


### PR DESCRIPTION
Don't attempt to update btime on share connectpath before share is fully initialized.