### PR TITLE
NAS-120269 / winbind: don't return nss results for local ids

### DIFF
--- a/source3/winbindd/winbindd_getgrgid.c
+++ b/source3/winbindd/winbindd_getgrgid.c
@@ -20,6 +20,7 @@
 #include "includes.h"
 #include "winbindd.h"
 #include "libcli/security/dom_sid.h"
+#include "passdb/machine_sid.h"
 
 struct winbindd_getgrgid_state {
 	struct tevent_context *ev;
@@ -80,7 +81,8 @@ static void winbindd_getgrgid_gid2sid_done(struct tevent_req *subreq)
 	if (tevent_req_nterror(req, status)) {
 		return;
 	}
-	if (is_null_sid(state->sid)) {
+	if (is_null_sid(state->sid) ||
+	    (dom_sid_compare_domain(state->sid, get_global_sam_sid()) == 0)) {
 		tevent_req_nterror(req, NT_STATUS_NO_SUCH_GROUP);
 		return;
 	}

--- a/source3/winbindd/winbindd_getgrnam.c
+++ b/source3/winbindd/winbindd_getgrnam.c
@@ -21,6 +21,7 @@
 #include "winbindd.h"
 #include "libcli/security/dom_sid.h"
 #include "lib/util/string_wrappers.h"
+#include "passdb/machine_sid.h"
 
 struct winbindd_getgrnam_state {
 	struct tevent_context *ev;
@@ -135,7 +136,10 @@ static void winbindd_getgrnam_lookupname_done(struct tevent_req *subreq)
 		tevent_req_nterror(req, NT_STATUS_NO_SUCH_GROUP);
 		return;
 	}
-
+	if (dom_sid_compare_domain(&state->sid, get_global_sam_sid()) == 0) {
+		tevent_req_nterror(req, NT_STATUS_NO_SUCH_GROUP);
+		return;
+	}
 	subreq = wb_getgrsid_send(state, state->ev, &state->sid,
 				  lp_winbind_expand_groups());
 	if (tevent_req_nomem(subreq, req)) {

--- a/source3/winbindd/winbindd_getpwuid.c
+++ b/source3/winbindd/winbindd_getpwuid.c
@@ -20,6 +20,7 @@
 #include "includes.h"
 #include "winbindd.h"
 #include "libcli/security/dom_sid.h"
+#include "passdb/machine_sid.h"
 
 struct winbindd_getpwuid_state {
 	struct tevent_context *ev;
@@ -78,7 +79,8 @@ static void winbindd_getpwuid_uid2sid_done(struct tevent_req *subreq)
 		D_WARNING("Failed with %s.\n", nt_errstr(status));
 		return;
 	}
-	if (is_null_sid(state->sid)) {
+	if (is_null_sid(state->sid) ||
+	    (dom_sid_compare_domain(state->sid, get_global_sam_sid()) == 0)) {
 		tevent_req_nterror(req, NT_STATUS_NO_SUCH_USER);
 		D_WARNING("Failed with NT_STATUS_NO_SUCH_USER.\n");
 		return;


### PR DESCRIPTION
If domain for SID is same as our local SID, don't return getpwnam, getpwuid, etc results. These should be returned via other NSS modules.