### PR TITLE
NAS-120414 / Always load DOSATTRIB xattr on Linux (#245)

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -206,23 +206,20 @@ static NTSTATUS ixnas_fget_dos_attributes(struct vfs_handle_struct *handle,
 							dosmode);
 	}
 #else
-	/*
-	 * update timestamps and dosmode from xattr before
-	 * applying the FS dos mode.
-	 *
-	 * This can be removed once we have OS / FS method
-	 * to change file birth time on Linux like on FreeBSD.e
-	 */
 	NTSTATUS status;
-	if (config->dosattrib_xattr) {
-		status = SMB_VFS_NEXT_FGET_DOS_ATTRIBUTES(handle,
-							  fsp,
-							  dosmode);
+	status = SMB_VFS_NEXT_FGET_DOS_ATTRIBUTES(handle,
+						  fsp,
+						  dosmode);
 
-		if (!NT_STATUS_IS_OK(status)) {
-			return status;
-		}
+	if (config->dosattrib_xattr) {
+		return status;
 	}
+
+	if (!NT_STATUS_IS_OK(status) &&
+	    !NT_STATUS_EQUAL(status, NT_STATUS_NOT_FOUND)) {
+		return status;
+	}
+
 #endif /* FREEBSD */
 
 	if (is_named_stream(fsp->fsp_name)) {


### PR DESCRIPTION
In case of Linux we want to always load the DOSATTRIB xattr regardless of ixnas configuration. The xattr is used to set the file's "itime", which is used to generate the MS-FSCC fileid, which is used by the MacOS client vnode cache as a key to uniquely identify the file.

In case of windows, the client uses QFid (which saner since it is derived from both devid and inode) rather than being a single 64-bit int. MacOS client effectively assumes that there are no nested filesystems within an SMB share.

This PR fixes broken logic whereby the DOSATTRIB xattr was only being loaded (on reads) if ZFS DOS modes were disabled.