### PR TITLE
s3: smbd: Always use metadata_fsp() when processing fsctls.

### DIFF
--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -1400,7 +1400,13 @@ static NTSTATUS vfswrap_fsctl(struct vfs_handle_struct *handle,
 	char **out_data = (char **)_out_data;
 	NTSTATUS status;
 
-	SMB_ASSERT(!fsp_is_alternate_stream(fsp));
+	/*
+	 * Currently all fsctls operate on the base
+	 * file if given an alternate data stream.
+	 * Revisit this if we implement fsctls later
+	 * that need access to the ADS handle.
+	 */
+	fsp = metadata_fsp(fsp);
 
 	switch (function) {
 	case FSCTL_SET_SPARSE:


### PR DESCRIPTION
Currently all fsctls we implement need the base fsp, not an alternate data stream fsp. We may revisit this later if we implement fsctls that operate on an ADS.

Remove knownfail.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=15236

Signed-off-by: Jeremy Allison <jra@samba.org>
Reviewed-by: Andrew Walker <awalker@ixsystems.com>

Autobuild-User(master): Jeremy Allison <jra@samba.org>
Autobuild-Date(master): Mon Nov 14 18:13:31 UTC 2022 on sn-devel-184

(cherry picked from commit fa4eba131b882c3858b28f5fd9864998e19a4510)