### PR TITLE
Fix smb_strtox for platforms not using glibc

### DIFF
--- a/lib/replace/replace.c
+++ b/lib/replace/replace.c
@@ -522,6 +522,25 @@ char *rep_strtok_r(char *s, const char *delim, char **save_ptr)
 }
 #endif
 
+#ifdef HAVE_BSD_STRTOLL
+#undef strtol
+long int rep_strtol(const char *str, char **endptr, int base)
+{
+	int saved_errno = errno;
+	long int nb = strtol(str, endptr, base);
+	/* With glibc EINVAL is only returned if base is not ok */
+	if (errno == EINVAL) {
+		if (base == 0 || (base >1 && base <37)) {
+			/* Base was ok so it's because we were not
+			 * able to make the conversion.
+			 * Let's reset errno.
+			 */
+			errno = saved_errno;
+		}
+	}
+	return nb;
+}
+#endif /* HAVE_BSD_STRTOLL */
 
 #ifndef HAVE_STRTOLL
 long long int rep_strtoll(const char *str, char **endptr, int base)
@@ -558,6 +577,25 @@ long long int rep_strtoll(const char *str, char **endptr, int base)
 #endif /* HAVE_BSD_STRTOLL */
 #endif /* HAVE_STRTOLL */
 
+#ifdef HAVE_BSD_STRTOLL
+#undef strtoul
+unsigned long int rep_strtoul(const char *str, char **endptr, int base)
+{
+	int saved_errno = errno;
+	unsigned long int nb = strtoul(str, endptr, base);
+	/* With glibc EINVAL is only returned if base is not ok */
+	if (errno == EINVAL) {
+		if (base == 0 || (base >1 && base <37)) {
+			/* Base was ok so it's because we were not
+			 * able to make the conversion.
+			 * Let's reset errno.
+			 */
+			errno = saved_errno;
+		}
+	}
+	return nb;
+}
+#endif /* HAVE_BSD_STRTOLL */
 
 #ifndef HAVE_STRTOULL
 unsigned long long int rep_strtoull(const char *str, char **endptr, int base)

--- a/lib/replace/replace.h
+++ b/lib/replace/replace.h
@@ -404,6 +404,15 @@ unsigned long long int rep_strtoull(const char *str, char **endptr, int base);
 #endif
 #endif
 
+#ifdef HAVE_BSD_STRTOLL
+#define strtoul rep_strtoul
+unsigned long int rep_strtoul(const char *str, char **endptr, int base);
+
+#define strtol rep_strtol
+long int rep_strtol(const char *str, char **endptr, int base);
+#endif
+
+
 #ifndef HAVE_FTRUNCATE
 #define ftruncate rep_ftruncate
 int rep_ftruncate(int,off_t);

--- a/lib/util/wscript_build
+++ b/lib/util/wscript_build
@@ -122,6 +122,7 @@ bld.SAMBA_SUBSYSTEM('samba-util-core',
 
 bld.SAMBA_SUBSYSTEM('smb_strtox',
                     source='smb_strtox.c',
+                    deps='replace',
                     local_include=False)
 
 


### PR DESCRIPTION
Some libc implementations of strtol and strtoul set errno to EINVAL in the situation where no conversion was performed. smb_strtox assumes glibc behavior. The build script already detects non-glibc strtoll implementation. This commit expands lib/replace to apply similar handling for strtol and strtoul.