### PR TITLE
lib/tevent - reduce strictness of checks for aio_cancel()

### DIFF
--- a/lib/tevent/tevent_kqueue.c
+++ b/lib/tevent/tevent_kqueue.c
@@ -855,18 +855,16 @@ static void tevent_aio_waitcomplete(struct tevent_context *ev, struct aiocb *ioc
 			"tevent_aio_waitcomplete(): aio_waitcomplete() failed: %s\n",
 			strerror(errno)
 		);
-		abort();
 	} else if (ret == EINPROGRESS) {
 		tevent_debug(
 			ev, TEVENT_DEBUG_FATAL,
 			"tevent_aio_waitcomplete(): aio_waitcomplete() "
 			"failed to complete after 30 seconds\n"
 		);
-		abort();
 	}
 }
 
-static bool tevent_aio_cancel(struct tevent_aiocb *taiocb)
+static void tevent_aio_cancel(struct tevent_aiocb *taiocb)
 {
 	int ret;
 	struct aiocb *iocbp = taiocb->iocbp;
@@ -894,7 +892,8 @@ static bool tevent_aio_cancel(struct tevent_aiocb *taiocb)
 		abort();
 	case AIO_NOTCANCELED:
 		ret = aio_error(iocbp);
-		if (ret == -1) {
+		if ((ret == -1) &&
+		    (errno != EAGAIN)) {
 			tevent_debug(
 				taiocb->ev, TEVENT_DEBUG_WARNING,
 				"tevent_aio_cancel(): "


### PR DESCRIPTION
On busy systems during SMB session teardown in abnormal circumstances it's possible that the session has in-flight IO that may not succssfully cancel. In some cases aio_cancel() for disk IO fails with EAGAIN while the internal iocb struct shows EINPROGRESS. In this situation pass through to aio_waitcomplete(). Convert errors in tevent_aio_waitcomplete() to be informative rather than asserting since we have better information now about what is triggering failures along this code path.