### PR TITLE
Use stored NFS4 ACL parameters (#262)

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -740,7 +740,7 @@ static NTSTATUS ixnas_fget_nt_acl(struct vfs_handle_struct *handle,
 		return status;
 	}
 
-	status = smb_fget_nt_acl_nfs4(fsp, NULL, security_info, mem_ctx,
+	status = smb_fget_nt_acl_nfs4(fsp, &config->nfs4_params, security_info, mem_ctx,
 				      ppdesc, pacl);
 	TALLOC_FREE(frame);
 	return status;


### PR DESCRIPTION
We cache the NFS4 ACL configuration parameters during tree connect. Pass these along to fget_nt_acl calls in the generic NFSv4 ACL framework to avoid having to look them up on each operation.