### PR TITLE
Skip delete_all_streams() if backed by xattr

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -685,6 +685,8 @@ typedef struct files_struct {
  * In any other case use fsp_get_io_fd().
  */
 #define TCON_FLAG_STAT_FAILED		0x01
+#define TCON_FLAG_STREAMS_XATTR		0x02
+#define TCON_FLAG_STREAMS_FILE		0x04
 
 #define FSP_POSIX_FLAGS_OPEN		0x01
 #define FSP_POSIX_FLAGS_RENAME		0x02

--- a/source3/modules/vfs_fruit.c
+++ b/source3/modules/vfs_fruit.c
@@ -304,6 +304,9 @@ static int init_fruit_config(vfs_handle_struct *handle)
 		return -1;
 	}
 	config->rsrc = (enum fruit_rsrc)enumval;
+	if (config->rsrc == FRUIT_RSRC_ADFILE) {
+		handle->conn->internal_tcon_flags |= TCON_FLAG_STREAMS_FILE;
+	}
 
 	enumval = lp_parm_enum(SNUM(handle->conn), FRUIT_PARAM_TYPE_NAME,
 			       "resource", fruit_rsrc, enumval);

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -907,6 +907,8 @@ static int streams_xattr_connect(vfs_handle_struct *handle,
 		return rc;
 	}
 
+	handle->conn->internal_tcon_flags |= TCON_FLAG_STREAMS_XATTR;
+
 	config = talloc_zero(handle->conn, struct streams_xattr_config);
 	if (config == NULL) {
 		DEBUG(1, ("talloc_zero() failed\n"));

--- a/source3/smbd/close.c
+++ b/source3/smbd/close.c
@@ -538,6 +538,7 @@ static NTSTATUS close_remove_share_mode(files_struct *fsp,
 	}
 
 	if ((conn->fs_capabilities & FILE_NAMED_STREAMS)
+	    && (conn->internal_tcon_flags & TCON_FLAG_STREAMS_FILE)
 	    && !fsp_is_alternate_stream(fsp)) {
 
 		status = delete_all_streams(conn, fsp->fsp_name);
@@ -1556,6 +1557,7 @@ static NTSTATUS close_directory(struct smb_request *req, files_struct *fsp,
 	}
 
 	if ((fsp->conn->fs_capabilities & FILE_NAMED_STREAMS)
+	    && (conn->internal_tcon_flags & TCON_FLAG_STREAMS_FILE)
 	    && !is_ntfs_stream_smb_fname(fsp->fsp_name)) {
 
 		status = delete_all_streams(fsp->conn, fsp->fsp_name);


### PR DESCRIPTION
Store stream location in TCON flag and skip delete_all_streams() if streams aren't file-backed.