### PR TITLE
Add VFS endpoint for optmized lookup

### DIFF
--- a/lib/util/memcache.h
+++ b/lib/util/memcache.h
@@ -48,6 +48,7 @@ enum memcache_number {
 	VIRUSFILTER_SCAN_RESULTS_CACHE_TALLOC, /* talloc */
 	DFREE_CACHE,
 	ZFS_CACHE,
+	FDHANDLE_CACHE,
 };
 
 /*

--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -395,6 +395,12 @@ enum acl_brand {
         SMB_ACL_BRAND_NONE,
 };
 
+enum fhandle_cache_op {
+	FHANDLE_GET_DEFAULT,
+	FHANDLE_GET_PATHREF,
+	FHANDLE_IS_CACHED,
+};
+
 struct fd_handle;
 
 struct fsp_lease {
@@ -976,6 +982,11 @@ struct vfs_fn_pointers {
 
 	/* File operations */
 
+	int (*fhandle_cache_lookup_fn)(struct vfs_handle_struct *handle,
+				       struct smb_filename *smb_fname,
+				       int flags,
+				       mode_t mode,
+				       enum fhandle_cache_op op);
 	int (*openat_fn)(struct vfs_handle_struct *handle,
 			 const struct files_struct *dirfsp,
 			 const struct smb_filename *smb_fname,
@@ -1457,6 +1468,11 @@ int smb_vfs_call_openat(struct vfs_handle_struct *handle,
 			struct files_struct *fsp,
 			int flags,
 			mode_t mode);
+int smb_vfs_call_fhandle_cache_lookup(struct vfs_handle_struct *handle,
+				      struct smb_filename *smb_fname,
+				      int flags,
+				      mode_t mode,
+				      enum fhandle_cache_op op);
 NTSTATUS smb_vfs_call_create_file(struct vfs_handle_struct *handle,
 				  struct smb_request *req,
 				  struct smb_filename *smb_fname,
@@ -1892,6 +1908,11 @@ int vfs_not_implemented_openat(vfs_handle_struct *handle,
 			       struct files_struct *fsp,
 			       int flags,
 			       mode_t mode);
+int vfs_not_implemented_fhandle_cache_lookup(struct vfs_handle_struct *handle,
+					     struct smb_filename *smb_fname,
+					     int flags,
+					     mode_t mode,
+					     enum fhandle_cache_op op);
 NTSTATUS vfs_not_implemented_create_file(struct vfs_handle_struct *handle,
 				struct smb_request *req,
 				struct smb_filename *smb_fname,

--- a/source3/include/vfs_macros.h
+++ b/source3/include/vfs_macros.h
@@ -142,6 +142,11 @@
 	smb_vfs_call_closedir((handle)->next, (dir))
 
 /* File operations */
+#define SMB_VFS_FHANDLE_CACHE_LOOKUP(conn, smb_fname, flags, mode, op) \
+	smb_vfs_call_fhandle_cache_lookup((conn)->vfs_handles, (smb_fname), (flags), (mode), (op))
+#define SMB_VFS_NEXT_FHANDLE_CACHE_LOOKUP(conn, smb_fname, flags, op) \
+	smb_vfs_call_fhandle_cache_lookup((conn)->vfs_handles->next, (smb_fname), (flags), (op))
+
 #define SMB_VFS_OPENAT(conn, dirfsp, smb_fname, fsp, flags, mode) \
 	smb_vfs_call_openat((conn)->vfs_handles, (dirfsp), (smb_fname), (fsp), (flags), (mode))
 #define SMB_VFS_NEXT_OPENAT(handle, dirfsp, smb_fname, fsp, flags, mode) \

--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -702,13 +702,6 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 
 	SMB_ASSERT(!is_named_stream(smb_fname));
 
-#ifdef O_RESOLVE_BENEATH
-	if ((handle->conn->internal_tcon_flags & TCON_FLAG_RESOLVE_BENEATH) &&
-	    !ISDOTDOT(smb_fname->base_name)) {
-		SMB_ASSERT(flags & (O_RESOLVE_BENEATH | O_EMPTY_PATH));
-	}
-#endif
-
 #ifdef O_PATH
 	have_opath = true;
 	if (fsp->fsp_flags.is_pathref) {
@@ -3987,6 +3980,7 @@ static struct vfs_fn_pointers vfs_default_fns = {
 
 	/* File operations */
 
+	.fhandle_cache_lookup_fn = vfs_not_implemented_fhandle_cache_lookup,
 	.openat_fn = vfswrap_openat,
 	.create_file_fn = vfswrap_create_file,
 	.close_fn = vfswrap_close,

--- a/source3/modules/vfs_not_implemented.c
+++ b/source3/modules/vfs_not_implemented.c
@@ -190,6 +190,16 @@ int vfs_not_implemented_closedir(vfs_handle_struct *handle, DIR *dir)
 	return -1;
 }
 
+int vfs_not_implemented_fhandle_cache_lookup(vfs_handle_struct *handle,
+					     struct smb_filename *smb_fname,
+					     int flags,
+					     mode_t mode,
+					     enum fhandle_cache_op op)
+{
+	errno = ENOSYS;
+	return -1;
+}
+
 int vfs_not_implemented_openat(vfs_handle_struct *handle,
 			       const struct files_struct *dirfsp,
 			       const struct smb_filename *smb_fname,
@@ -984,6 +994,7 @@ static struct vfs_fn_pointers vfs_not_implemented_fns = {
 
 	/* File operations */
 
+	.fhandle_cache_lookup_fn = vfs_not_implemented_fhandle_cache_lookup,
 	.openat_fn = vfs_not_implemented_openat,
 	.create_file_fn = vfs_not_implemented_create_file,
 	.close_fn = vfs_not_implemented_close_fn,

--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -359,9 +359,8 @@ static int streams_xattr_openat(struct vfs_handle_struct *handle,
 		return vfs_fake_fd();
 	}
 #endif
-	if (!(handle->conn->internal_tcon_flags & TCON_FLAG_RESOLVE_BENEATH)) {
-		SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
-	}
+	SMB_ASSERT(fsp_get_pathref_fd(dirfsp) == AT_FDCWD);
+
 	fsp->fsp_flags.have_proc_fds = fsp->conn->have_proc_fds;
 
 	status = streams_xattr_get_name(handle, talloc_tos(),

--- a/source3/smbd/files.c
+++ b/source3/smbd/files.c
@@ -724,10 +724,12 @@ NTSTATUS parent_pathref(TALLOC_CTX *mem_ctx,
 	 */
 	parent->flags &= ~SMB_FILENAME_POSIX_PATH;
 
-	ret = vfs_stat(dirfsp->conn, parent);
-	if (ret != 0) {
-		TALLOC_FREE(parent);
-		return map_nt_error_from_unix(errno);
+	if (!VALID_STAT(parent->st)) {
+		ret = vfs_stat(dirfsp->conn, parent);
+		if (ret != 0) {
+			TALLOC_FREE(parent);
+			return map_nt_error_from_unix(errno);
+		}
 	}
 
 	status = openat_pathref_fsp(dirfsp, parent);

--- a/source3/smbd/vfs.c
+++ b/source3/smbd/vfs.c
@@ -1150,6 +1150,15 @@ NTSTATUS check_reduced_name(connection_struct *conn,
 
 	DBG_DEBUG("check_reduced_name [%s] [%s]\n", fname, conn->connectpath);
 
+	if (VALID_STAT(smb_fname->st)) {
+		int rv;
+
+		rv = SMB_VFS_FHANDLE_CACHE_LOOKUP(conn, smb_fname, 0, 0, FHANDLE_IS_CACHED);
+		if (rv == 0) {
+			return NT_STATUS_OK;
+		}
+	}
+
 	resolved_fname = SMB_VFS_REALPATH(conn, ctx, smb_fname);
 
 	if (resolved_fname == NULL) {
@@ -1727,6 +1736,20 @@ int smb_vfs_call_closedir(struct vfs_handle_struct *handle,
 {
 	VFS_FIND(closedir);
 	return handle->fns->closedir_fn(handle, dir);
+}
+
+int smb_vfs_call_fhandle_cache_lookup(struct vfs_handle_struct *handle,
+				      struct smb_filename *smb_fname,
+				      int flags,
+				      mode_t mode,
+				      enum fhandle_cache_op op)
+{
+	VFS_FIND(fhandle_cache_lookup);
+	return handle->fns->fhandle_cache_lookup_fn(handle,
+						    smb_fname,
+						    flags,
+						    mode,
+						    op);
 }
 
 int smb_vfs_call_openat(struct vfs_handle_struct *handle,


### PR DESCRIPTION
Provide non-default fast-path for handle lookups within Samba's vfs. The fast-path in this case is an RB-tree keyed on device-inode pairs containing fhandle_t handle that can be used to open a file in a race- free manner without having to lookup vnode. Cache is populated during directory listing. When we are able to successfully open from the fhandle cache, we can skip symlink safety checks which results in significant performance improvement for workloads involving large numbers of files.