### PR TITLE
libcli/http - apply upstream freebsd port fix

### DIFF
--- a/libcli/http/http.c
+++ b/libcli/http/http.c
@@ -142,7 +142,19 @@ static enum http_read_status http_parse_headers(struct http_read_response_state 
 		return HTTP_ALL_DATA_READ;
 	}
 
+#ifdef FREEBSD
+	int s0, s1, s2, s3; s0 = s1 = s2 = s3 = 0;
+	n = sscanf(line, "%n%*[^:]%n: %n%*[^\r\n]%n\r\n", &s0, &s1, &s2, &s3);
+
+	if(n >= 0) {
+		key = calloc(sizeof(char), s1-s0+1);
+		value = calloc(sizeof(char), s3-s2+1);
+
+		n = sscanf(line, "%[^:]: %[^\r\n]\r\n", key, value);
+	}
+#else
 	n = sscanf(line, "%m[^:]: %m[^\r\n]\r\n", &key, &value);
+#endif
 	if (n != 2) {
 		DEBUG(0, ("%s: Error parsing header '%s'\n", __func__, line));
 		status = HTTP_DATA_CORRUPTED;
@@ -168,7 +180,7 @@ error:
 static bool http_parse_response_line(struct http_read_response_state *state)
 {
 	bool	status = true;
-	char	*protocol;
+	char	*protocol = NULL;
 	char	*msg = NULL;
 	char	major;
 	char	minor;
@@ -188,18 +200,32 @@ static bool http_parse_response_line(struct http_read_response_state *state)
 		return false;
 	}
 
+#ifdef FREEBSD
+	int s0, s1, s2, s3; s0 = s1 = s2 = s3 = 0;
+	n = sscanf(line, "%n%*[^/]%n/%c.%c %d %n%*[^\r\n]%n\r\n",
+		   &s0, &s1, &major, &minor, &code, &s2, &s3);
+
+	if(n == 3) {
+		protocol = calloc(sizeof(char), s1-s0+1);
+		msg = calloc(sizeof(char), s3-s2+1);
+
+		n = sscanf(line, "%[^/]/%c.%c %d %[^\r\n]\r\n",
+			protocol, &major, &minor, &code, msg);
+	}
+#else
 	n = sscanf(line, "%m[^/]/%c.%c %d %m[^\r\n]\r\n",
 		   &protocol, &major, &minor, &code, &msg);
-
-	DEBUG(11, ("%s: Header parsed(%i): protocol->%s, major->%c, minor->%c, "
-		   "code->%d, message->%s\n", __func__, n, protocol, major, minor,
-		   code, msg));
+#endif
 
 	if (n != 5) {
 		DEBUG(0, ("%s: Error parsing header\n",	__func__));
 		status = false;
 		goto error;
 	}
+
+	DEBUG(11, ("%s: Header parsed(%i): protocol->%s, major->%c, minor->%c, "
+		   "code->%d, message->%s\n", __func__, n, protocol, major, minor,
+		   code, msg));
 
 	if (major != '1') {
 		DEBUG(0, ("%s: Bad HTTP major number '%c'\n", __func__, major));


### PR DESCRIPTION
Fix linuxisms in http parser used by spotlight in samba.