### PR TITLE
NAS-122455 / s3/winbindd - prevent lookup_name recursion

### DIFF
--- a/source3/winbindd/winbindd_getgroups.c
+++ b/source3/winbindd/winbindd_getgroups.c
@@ -90,7 +90,7 @@ struct tevent_req *winbindd_getgroups_send(TALLOC_CTX *mem_ctx,
 				    state->namespace,
 				    state->domname,
 				    state->username,
-				    LOOKUP_NAME_NO_NSS);
+				    LOOKUP_NAME_NO_NSS | LOOKUP_NAME_REMOTE);
 	if (tevent_req_nomem(subreq, req)) {
 		return tevent_req_post(req, ev);
 	}

--- a/source3/winbindd/winbindd_getpwnam.c
+++ b/source3/winbindd/winbindd_getpwnam.c
@@ -87,7 +87,7 @@ struct tevent_req *winbindd_getpwnam_send(TALLOC_CTX *mem_ctx,
 				    state->namespace,
 				    state->domname,
 				    state->username,
-				    LOOKUP_NAME_NO_NSS);
+				    LOOKUP_NAME_NO_NSS | LOOKUP_NAME_REMOTE);
 	if (tevent_req_nomem(subreq, req)) {
 		return tevent_req_post(req, ev);
 	}


### PR DESCRIPTION
If username is not lowercase then uncached wb_lookupname will enter into recursive loop in which it tries to look up a lowercase version of the name until the request hits the winbind request timeout.