### PR TITLE
NAS-123078 / shadow_copy_zfs: fix VSS access for deleted files

### DIFF
--- a/source3/smbd/filename.c
+++ b/source3/smbd/filename.c
@@ -1135,7 +1135,7 @@ static NTSTATUS filename_convert_dirfsp_nosymlink(
 			mem_ctx,
 			conn,
 			dirname,
-			0,
+			twrp,
 			posix,
 			&smb_dirname,
 			&unparsed,


### PR DESCRIPTION
This fixes two issues:
1) source3/smbd/filename.c was stripping timestamp info when trying
   to generate a path for parent directory access. This was immediate
   cause of reported issue.
2) In some situations client may perform FSCTL operation to enumerate
   previous versions of files on a handle that's for previous version
   of a file. We need to convert the file's path in this case to the
   dataset mountpoint (not snapshot mountpoint) prior to opening a
   ZFS dataset handle.