### PR TITLE
NAS-123376 / Add synonyms for read list and write list

### DIFF
--- a/docs-xml/smbdotconf/security/readlist.xml
+++ b/docs-xml/smbdotconf/security/readlist.xml
@@ -2,6 +2,7 @@
                  context="S"
                  type="cmdlist"
                  xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<synonym>rolist</synonym>
 <description>
     <para>
 	This is a list of users that are given read-only access to a service. If the connecting user is in this list

--- a/docs-xml/smbdotconf/security/writelist.xml
+++ b/docs-xml/smbdotconf/security/writelist.xml
@@ -2,6 +2,7 @@
                  context="S"
                  type="cmdlist"
                  xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<synonym>rwlist</synonym>
 <description>
     <para>
     This is a list of users that are given read-write access to a service. If the 


### PR DESCRIPTION
An old DB migration had typos for read list and write list.