### PR TITLE
NAS-118707 - remove case sensitivity optimization

### DIFF
--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -736,14 +736,6 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 		set_base_user_quota(handle, config, user);
         }
 
-	if (config->ds->properties->casesens == SMBZFS_INSENSITIVE) {
-		DBG_INFO("zfs_core: case insensitive dataset detected, "
-			 "automatically adjusting case sensitivity settings.\n");
-		lp_do_parameter(SNUM(handle->conn),
-				"case sensitive", "yes");
-		handle->conn->case_sensitive = True;
-	}
-
 	config->zfs_space_enabled = lp_parm_bool(SNUM(handle->conn),
 			"zfs_core", "zfs_space_enabled", false);
 


### PR DESCRIPTION
ms_fn_match was not returning results expected to clients based on mask set by client. Further investigation of performance impact on directory listings due to this will be required.