### PR TITLE
Improve error handling for snapdir open failure

### DIFF
--- a/source3/modules/smb_libzfs.h
+++ b/source3/modules/smb_libzfs.h
@@ -61,8 +61,8 @@ struct snapshot_list
 struct snap_filter
 {
 	bool ignore_empty_snaps;
-	const char **inclusions;
-	const char **exclusions;
+	char **inclusions;
+	char **exclusions;
 	time_t start;
 	time_t end;
 	uint64_t start_txg;


### PR DESCRIPTION
If we fail to O_DIRECTORY open the snapdir mountpoint, then close our initial O_PATH open and pass error back up VFS stack rather than SMB_ASSERT().