### PR TITLE
NAS-123900 / source3/smblibzfs - cache userquota and groupquota

### DIFF
--- a/source3/modules/smb_libzfs.h
+++ b/source3/modules/smb_libzfs.h
@@ -72,9 +72,8 @@ struct snap_filter
 enum casesensitivity {SMBZFS_SENSITIVE, SMBZFS_INSENSITIVE, SMBZFS_MIXED};
 
 enum zfs_quotatype {
-	SMBZFS_USER_QUOTA,
+	SMBZFS_USER_QUOTA = 0,
 	SMBZFS_GROUP_QUOTA,
-	SMBZFS_DATASET_QUOTA
 };
 
 struct zfs_quota {


### PR DESCRIPTION
Some clients will request userquota and groupquota for every file in a directory for each dir listing. These requests are specifically for quotas impacting the euid and egid. This results in a huge amount of libzfs requests that are pointless because the quotas apply at dataset and not file level. To back off the herd of requests this PR implements a cache of last userquota and group quota requested and if the user / group ID and device ID match (and a 10 second timeout hasn't expired) we return the results of the last cache.

Cache is updated on setquota request.