### PR TITLE
NAS-123522 / Fix open flags for fremovexattr

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -2127,6 +2127,7 @@ static int ixnas_fremovexattr(struct vfs_handle_struct *handle, struct files_str
 {
 	int fd = fsp_get_pathref_fd(fsp);
 	int tmp_fd;
+	int open_flags = O_EMPTY_PATH;
 	int error;
 
 	SMB_ASSERT(!fsp_is_alternate_stream(fsp));
@@ -2135,7 +2136,8 @@ static int ixnas_fremovexattr(struct vfs_handle_struct *handle, struct files_str
 		return fremovexattr(fd, name);
 	}
 
-	tmp_fd = openat(fd, "", O_EMPTY_PATH | O_RDWR);
+	open_flags |= S_ISDIR(fsp->fsp_name->st.st_ex_mode) ? O_DIRECTORY : O_RDWR;
+	tmp_fd = openat(fd, "", open_flags);
 	if (tmp_fd == -1) {
 		DBG_ERR("%s: failed to reopen O_PATH descriptor: %s\n",
 			fsp_str_dbg(fsp), strerror(errno));


### PR DESCRIPTION
This impacts ability to delete directories with color tags for cases where non-default vfs_fruit parameters are in use.