### PR TITLE
NAS-124475 - s3/winbindd - don't spam for NULL SIDs

### DIFF
--- a/source3/winbindd/winbindd_getgrnam.c
+++ b/source3/winbindd/winbindd_getgrnam.c
@@ -176,9 +176,11 @@ NTSTATUS winbindd_getgrnam_recv(struct tevent_req *req,
 
 	if (tevent_req_is_nterror(req, &status)) {
 		struct dom_sid_buf sidbuf;
-		D_WARNING("Could not convert sid %s: %s\n",
-			  dom_sid_str_buf(&state->sid, &sidbuf),
-			  nt_errstr(status));
+		if (!is_null_sid(&state->sid)) {
+			D_WARNING("Could not convert sid %s: %s\n",
+				  dom_sid_str_buf(&state->sid, &sidbuf),
+				  nt_errstr(status));
+		}
 		return status;
 	}
 

--- a/source3/winbindd/winbindd_getpwnam.c
+++ b/source3/winbindd/winbindd_getpwnam.c
@@ -143,9 +143,11 @@ NTSTATUS winbindd_getpwnam_recv(struct tevent_req *req,
 
 	if (tevent_req_is_nterror(req, &status)) {
 		struct dom_sid_buf buf;
-		D_WARNING("Could not convert sid %s: %s\n",
-			  dom_sid_str_buf(&state->sid, &buf),
-			  nt_errstr(status));
+		if (!is_null_sid(&state->sid)) {
+			D_WARNING("Could not convert sid %s: %s\n",
+				  dom_sid_str_buf(&state->sid, &buf),
+				  nt_errstr(status));
+		}
 		return status;
 	}
 	response->data.pw = state->pw;


### PR DESCRIPTION
If getgrnam_lookup from nss_winbind fails it will return a NULL sid to the async receive function for getpwam and getgrnam. This can lead to excessive log churn if an application is mindlessly requesting non-existent users and groups.