### PR TITLE
Expand information in audit messages

### DIFF
--- a/source3/modules/vfs_truenas_audit.h
+++ b/source3/modules/vfs_truenas_audit.h
@@ -105,6 +105,7 @@ typedef struct truenas_audit_vfs_extension {
 	struct timespec last_write;
 	struct timespec last_offload_write;
 	struct file_id_buf fid_str;
+	struct smb_filename *cached_fname;
 } tn_audit_ext_t;
 
 typedef enum tn_audit_op {

--- a/source3/modules/vfs_truenas_audit_rw.c
+++ b/source3/modules/vfs_truenas_audit_rw.c
@@ -82,6 +82,7 @@ static bool tn_log_rw_common(vfs_handle_struct *handle,
 	struct json_object msg, entry;
 	struct timespec now, *old = NULL;
 	bool ok;
+	uint32_t js_flags = FILE_ADD_NAME | FILE_NAME_IS_PATH | FILE_ADD_HANDLE;
 	tn_audit_conf_t *config = NULL;
 
 	SMB_VFS_HANDLE_GET_DATA(handle, config, tn_audit_conf_t,
@@ -151,7 +152,7 @@ static bool tn_log_rw_common(vfs_handle_struct *handle,
 		return false;
 	}
 
-	ok = tn_add_file_to_object(fsp->fsp_name, fsp_ext, "file", FILE_ADD_HANDLE, &entry);
+	ok = tn_add_file_to_object(NULL, fsp_ext, "file", js_flags, &entry);
 	if (!ok) {
 		goto cleanup;
 	}

--- a/source3/modules/vfs_truenas_audit_utils.c
+++ b/source3/modules/vfs_truenas_audit_utils.c
@@ -181,7 +181,7 @@ bool tn_add_file_type_to_object(struct json_object *jsobj,
 	return false;
 }
 
-bool _tn_add_file_to_object(const struct smb_filename *fname,
+bool _tn_add_file_to_object(const struct smb_filename *fname_in,
 			    const tn_audit_ext_t *fsp_ext,
 			    const char *key,
 			    uint32_t flags,
@@ -192,6 +192,11 @@ bool _tn_add_file_to_object(const struct smb_filename *fname,
 	bool ok;
 	struct json_object wrapper, fhandle;
 	const char *namekey = flags & FILE_NAME_IS_PATH ? "path" : "name";
+	const struct smb_filename *fname = NULL;
+
+	SMB_ASSERT(fname_in || (fsp_ext && fsp_ext->cached_fname));
+
+	fname = fname_in ? fname_in : fsp_ext->cached_fname;
 
 	if (json_is_invalid(jsobj)) {
 		DBG_ERR("%s: Unable to add file information to object. "


### PR DESCRIPTION
The webui team asked for full file information in audit messages so that it will be easier for users to search.