### PR TITLE
NAS-125567 / s3:utils:status - add num_channels to smbstatus

### DIFF
--- a/source3/utils/conn_tdb.c
+++ b/source3/utils/conn_tdb.c
@@ -45,6 +45,7 @@ struct connections_forall_session {
 	uint16_t dialect;
 	uint16_t signing;
 	uint8_t signing_flags;
+	uint32_t num_channels;
 };
 
 static int collect_sessions_fn(struct smbXsrv_session_global0 *global,
@@ -70,6 +71,7 @@ static int collect_sessions_fn(struct smbXsrv_session_global0 *global,
 	sess.signing = global->channels[0].signing_algo;
 	sess.dialect = global->connection_dialect;
 	sess.signing_flags = global->signing_flags;
+	sess.num_channels = global->num_channels;
 
 	status = dbwrap_store(state->session_by_pid,
 			      make_tdb_data((void*)&id, sizeof(id)),
@@ -134,6 +136,7 @@ static int traverse_tcon_fn(struct smbXsrv_tcon_global0 *global,
 	data.dialect = sess.dialect;
 	data.signing = sess.signing;
 	data.signing_flags = global->signing_flags;
+	data.num_channels = sess.num_channels;
 
 	state->count++;
 

--- a/source3/utils/conn_tdb.h
+++ b/source3/utils/conn_tdb.h
@@ -34,6 +34,7 @@ struct connections_data {
 	uint16_t dialect;
 	uint8_t signing_flags;
 	uint16_t signing;
+	uint32_t num_channels;
 };
 
 /* The following definitions come from lib/conn_tdb.c  */

--- a/source3/utils/status_json.c
+++ b/source3/utils/status_json.c
@@ -365,6 +365,11 @@ int traverse_connections_json(struct traverse_state *state,
 		goto failure;
 	}
 
+	result = json_add_int(&sub_json, "num_channels", crec->num_channels);
+	if (result < 0) {
+		goto failure;
+	}
+
 	result = json_add_object(&connections_json, tcon_id_str, &sub_json);
 	if (result < 0) {
 		goto failure;


### PR DESCRIPTION
Add key to JSON output of smbstatus to indicate the number of channels that are in-use by connection.