### PR TITLE
NAS-126732 / Remove openat2 fallback

### DIFF
--- a/lib/replace/replace.c
+++ b/lib/replace/replace.c
@@ -1236,8 +1236,7 @@ long rep_openat2(int dirfd, const char *pathname,
 
 	return openat(dirfd, pathname, flags, how->mode);
 #else
-	errno = ENOSYS;
-	return -1;
+#error "no openat2 implementation"
 #endif
 }
 #endif /* !HAVE_OPENAT2 */

--- a/lib/replace/system/filesys.h
+++ b/lib/replace/system/filesys.h
@@ -245,6 +245,8 @@ int rep_fsetxattr (int filedes, const char *name, const void *value, size_t size
 
 #ifdef HAVE_LINUX_OPENAT2_H
 #include <linux/openat2.h>
+#elif HAVE_SYS_OPENAT2_H
+#include <sys/openat2.h>
 #else /* ! HAVE_LINUX_OPENAT2_H */
 /* how->resolve flags for openat2(2). */
 #define RESOLVE_NO_XDEV		0x01 /* Block mount-point crossings

--- a/lib/replace/wscript
+++ b/lib/replace/wscript
@@ -66,6 +66,8 @@ def configure(conf):
     conf.CHECK_HEADERS('getopt.h iconv.h')
     conf.CHECK_HEADERS('memory.h nss.h sasl/sasl.h')
     conf.CHECK_HEADERS('linux/openat2.h')
+    conf.CHECK_HEADERS('sys/openat2.h')
+    conf.CHECK_FUNCS('openat2')
 
     conf.CHECK_FUNCS_IN('inotify_init', 'inotify', checklibc=True,
                         headers='sys/inotify.h')

--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -709,17 +709,6 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 				 &linux_how,
 				 sizeof(linux_how));
 		if (result == -1) {
-			if (errno == ENOSYS) {
-				/*
-				 * The kernel doesn't support
-				 * openat2(), so indicate to
-				 * the callers that
-				 * VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS
-				 * would just be a waste of time.
-				 */
-				fsp->conn->open_how_resolve &=
-					~VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS;
-			}
 			goto out;
 		}
 


### PR DESCRIPTION
We will have some implemenatation of openat2 in both SCALE and Core. Remove unnecessary fallback code to avoid unwanted code paths from being compiled and followed.