### PR TITLE
NAS-126733 / Fix vfs_tmprotect build failure on FreeBSD

### DIFF
--- a/source3/modules/vfs_tmprotect.c
+++ b/source3/modules/vfs_tmprotect.c
@@ -185,12 +185,17 @@ static FILE *open_history(const char *history_path)
 	 */
 	FILE *history = NULL;
 	int fd;
+
+#ifndef FREEBSD
 	struct open_how how = {
 		.flags = O_RDONLY,
 		.resolve = RESOLVE_NO_SYMLINKS
 	};
-
 	fd = openat2(AT_FDCWD, history_path, &how, sizeof(how));
+
+#else
+	fd = openat(AT_FDCWD, history_path, O_RDONLY | O_RESOLVE_BENEATH);
+#endif
 	if (fd == -1) {
 		DBG_ERR("%s: failed to open history path: %s\n",
 			history_path, strerror(errno));


### PR DESCRIPTION
vfs_tmprotect fails to build on FreeBSD when it lacks openat2. This commit replaces the restricted open for the time machine history file with an equivalent-ish one for FreeBSD using O_RESOLVE_BENEATH (this still prevents a symlink from breaking out of the SMB share's root directory).