### PR TITLE
NAS-126747 / s3/lib/idmap_cache - don't cache Unix account sids

### DIFF
--- a/source3/wscript_build
+++ b/source3/wscript_build
@@ -384,6 +384,7 @@ bld.SAMBA3_SUBSYSTEM('samba3core',
                           lib/idmap_cache.c
                           lib/namemap_cache.c
                           lib/util_ea.c
+                          lib/util_unixsids.c
                           lib/background.c
                           ''',
                    deps='''


### PR DESCRIPTION
Local unix users and groups are implicitly mapped with a special samba SID prefix. This means that queries for instance for S-1-22-1-3000 will resolve to UID 3000 and generate a reverse UID to SID mapping that overwrites any prior one retrieved via passdb. This commit prevents us from storing the reverse mapping for these account SIDs in gencache to avoid pollution.