### PR TITLE
s3/modules/streams_xattr - override ZFS_READONLY for ADS (#363)

### DIFF
--- a/source3/modules/vfs_streams_xattr.c
+++ b/source3/modules/vfs_streams_xattr.c
@@ -46,6 +46,16 @@ struct stream_io {
 	vfs_handle_struct *handle;
 };
 
+static bool can_write_ea(files_struct *fsp)
+{
+	NTSTATUS status;
+	status = smbd_check_access_rights_fsp(fsp->conn->cwd_fsp,
+					      fsp,
+					      false,
+					      SEC_FILE_WRITE_EA);
+	return NT_STATUS_IS_OK(status);
+}
+
 static ssize_t get_xattr_size_fsp(vfs_handle_struct *handle,
 				  struct files_struct *fsp,
 			          const char *xattr_name)
@@ -1025,6 +1035,20 @@ static ssize_t streams_xattr_pwrite(vfs_handle_struct *handle,
 				ea.value.data,
 				ea.value.length,
 				0);
+
+	if ((ret == -1) && (errno == EACCES)) {
+		bool ok;
+		ok = can_write_ea(fsp->base_fsp);
+		if (ok) {
+			become_root();
+			ret = SMB_VFS_FSETXATTR(fsp->base_fsp,
+						sio->xattr_name,
+						ea.value.data,
+						ea.value.length,
+						0);
+			unbecome_root();
+		}
+	}
 	TALLOC_FREE(ea.value.data);
 
 	if (ret == -1) {
@@ -1307,6 +1331,20 @@ static int streams_xattr_ftruncate(struct vfs_handle_struct *handle,
 				ea.value.data,
 				ea.value.length,
 				0);
+
+	if ((ret == -1) && (errno == EACCES)) {
+		bool ok;
+		ok = can_write_ea(fsp->base_fsp);
+		if (ok) {
+			become_root();
+			ret = SMB_VFS_FSETXATTR(fsp->base_fsp,
+						sio->xattr_name,
+						ea.value.data,
+						ea.value.length,
+						0);
+			unbecome_root();
+		}
+	}
 
 	TALLOC_FREE(ea.value.data);
 


### PR DESCRIPTION
Currently the ZFS_READONLY attribute prevents xattr writes on files even if the same handle is used for xattr writes as was used to initially set the READONLY property. When Windows clients copy a file with an alternate data stream present and the DOS readonly flag set, it will perform the following operations:

* Create file with READONLY set
* Write file data
* Write alternate data streams

The first two items are handled correctly with ZFS_READONLY, but the last operation fails with EACCES. Until this issue can be addressed in openzfs, check for failure with EACCES on ADS write and if that happened, check our file permissions for whether EA writes are allowed, then redo the operations as root.