### PR TITLE
NAS-127244 / Set IOSQE_ASYNC for io_uring reads

### DIFF
--- a/source3/modules/vfs_io_uring.c
+++ b/source3/modules/vfs_io_uring.c
@@ -229,7 +229,7 @@ static int vfs_io_uring_connect(vfs_handle_struct *handle, const char *service,
 	force_aio_read = lp_parm_bool(SNUM(handle->conn),
 				      "io_uring",
 				      "iosqe_async_read",
-				      false);
+				      true);
 	if (force_aio_read) {
 		config->async_ops |= IO_URING_ASYNC_READ;
 	}


### PR DESCRIPTION
Currently on ZFS reads via io_uring will default to synchronous unless IOSQE_ASYNC is forced. In some situations this proved to be a performance bottleneck. Future samba enhancement will use a memory pool to help avoid page faults on this code path.