### PR TITLE
NAS-127388 / Add truenas_mempool library for reusing buffers (#368)

### DIFF
--- a/source3/lib/truenas_mempool.c
+++ b/source3/lib/truenas_mempool.c
@@ -1,0 +1,184 @@
+/*
+ * Use memory pool under global server context
+ *
+ * Copyright (C) iXsystems, Inc. 2024
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "includes.h"
+#include "smbd/globals.h"
+#include "../lib/util/tevent_ntstatus.h"
+#include "../lib/util/tevent_unix.h"
+
+#define MEM_POOL_SZ (16 * 1024 * 1024)
+#define IO_POOL_IDLE_TIMEOUT 300
+
+/* Count of allocations out of memory pool */
+static uint alloc_cnt;
+
+static struct tevent_timer *io_buffer_timer;
+static struct timespec last_alloc;
+
+struct io_pool_link { uint8_t *to_free; };
+
+static int io_buffer_destroy(struct io_pool_link *lnk)
+{
+	/*
+	 * This is the destructor function for linkage between
+	 * between allocations out of our memory pool and is
+	 * used for keeping track of how many outstanding
+	 * allocations there are. In the case of data blobs,
+	 * the linkage is created external to this library in order
+	 * to allow a mechanism to effectively reparent the buffer under
+	 * a different memory context.
+	 */
+	if (lnk->to_free) {
+		TALLOC_FREE(lnk->to_free);
+	}
+	SMB_ASSERT(alloc_cnt > 0);
+	alloc_cnt -= 1;
+	return 0;
+}
+
+bool link_io_buffer_blob(TALLOC_CTX *mem_ctx, DATA_BLOB *buf)
+{
+	struct io_pool_link *lnk = NULL;
+
+	SMB_ASSERT(buf->data != NULL);
+
+	lnk = talloc_zero(mem_ctx, struct io_pool_link);
+	if (lnk == NULL) {
+		return false;
+	}
+	lnk->to_free = buf->data;
+	talloc_set_destructor(lnk, io_buffer_destroy);
+	return true;
+}
+
+static bool link_io_buffer(TALLOC_CTX *mem_ctx)
+{
+	// This linkage is used to keep count of memory allocations
+	// from the pool
+	struct io_pool_link *lnk = NULL;
+
+	lnk = talloc_zero(mem_ctx, struct io_pool_link);
+	if (lnk == NULL) {
+		return false;
+	}
+
+	talloc_set_destructor(lnk, io_buffer_destroy);
+	return true;
+}
+
+static void io_pool_time_handler(struct tevent_context *ctx,
+				 struct tevent_timer *te,
+				 struct timeval now,
+				 void *private_data)
+{
+	// This is an idle timer. We want to free the io memory
+	// pool if the smbd process is not using it for more than
+	// five minutes.
+	struct smbd_server_connection *sconn = NULL;
+	struct timespec mono_now;
+	int err;
+
+	sconn = (struct smbd_server_connection *)private_data;
+	SMB_ASSERT(sconn != NULL);
+
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &mono_now);
+
+	if ((alloc_cnt == 0) &&
+	    (timespec_elapsed2(&last_alloc, &mono_now) > IO_POOL_IDLE_TIMEOUT)){
+		TALLOC_FREE(sconn->io_memory_pool);
+		io_buffer_timer = NULL;
+		return;
+	}
+
+	// now is timeval based on realtime clock (not monotonic time)
+	now.tv_sec += IO_POOL_IDLE_TIMEOUT;
+	io_buffer_timer = tevent_add_timer(sconn->ev_ctx, NULL,
+					   now, io_pool_time_handler,
+					   sconn);
+}
+
+static bool init_io_pool(struct smbd_server_connection *sconn)
+{
+	// Allocate the memory pool if needed and then set the idle
+	// timer.
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &last_alloc);
+	if (sconn->io_memory_pool == NULL) {
+		sconn->io_memory_pool = talloc_pool(sconn, MEM_POOL_SZ);
+		if (sconn->io_memory_pool == NULL) {
+			return false;
+		}
+	}
+
+	if (io_buffer_timer == NULL) {
+		// tevent timers are based on CLOCK_REALTIME
+		struct timeval interval;
+		interval = timeval_current_ofs(IO_POOL_IDLE_TIMEOUT, 0);
+
+		io_buffer_timer = tevent_add_timer(sconn->ev_ctx, NULL,
+						   interval,
+						   io_pool_time_handler, sconn);
+	}
+
+	return true;
+}
+
+bool io_pool_alloc_blob(struct connection_struct *conn,
+			size_t buflen,
+			DATA_BLOB *out)
+{
+	DATA_BLOB buf = { 0 };
+
+	if (!init_io_pool(conn->sconn)) {
+		return false;
+	}
+
+	buf = data_blob_talloc(conn->sconn->io_memory_pool, NULL, buflen);
+	if (buf.data == NULL) {
+		return false;
+	}
+
+	*out = buf;
+	alloc_cnt += 1;
+	return true;
+}
+
+void *_io_pool_calloc_size(struct connection_struct *conn, size_t size,
+			   const char *name, const char *location)
+{
+	void *out = NULL;
+
+	if (!init_io_pool(conn->sconn)) {
+		return NULL;
+	}
+
+	out = talloc_zero_size(conn, size);
+	if (out == NULL) {
+		return NULL;
+	}
+
+	talloc_set_name_const(out, name ? name : location);
+	alloc_cnt += 1;
+
+	if (!link_io_buffer(out)) {
+		TALLOC_FREE(out);
+		return NULL;
+	}
+
+	return out;
+}

--- a/source3/lib/truenas_mempool.h
+++ b/source3/lib/truenas_mempool.h
@@ -1,0 +1,78 @@
+/*
+ * Use memory pool under global server context
+ *
+ * Copyright (C) iXsystems, Inc. 2024
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/**
+ * @brief Link the specified data blob to the specified memory context
+ *	  This is done so that when the specified context is freed
+ *	  the buffer associated the the specified DATA_BLOB is also
+ *	  freed. This may be used in lieu of talloc_steal of the buffer,
+ *	  and is required when memory pool is in use in order to ensure
+ *	  that memory is released to the pool c.f. documentation for
+ *	  talloc_pool(). A DATA_BLOB must be linked to no more than
+ *	  one talloc context.
+ *
+ * @param[in]	ctx		The talloc context for the link
+ * @param[in]	buf		Buffer to link to the context
+ *
+ * @return	true on success false on failure.
+ */
+bool link_io_buffer_blob(TALLOC_CTX *mem_ctx, DATA_BLOB *buf);
+
+/**
+ * @brief Allocate a DATA_BLOB with a buffer size specified by buflen
+ * 	  using memory in the io_memory_pool.
+ *
+ * @param[in]	conn		The current tree connection
+ * @param[in]	buflen		size of buffer to allocate
+ * @param[buf]	out 		New DATA_BLOB with buffer
+ *
+ * @return	true on success false on failure.
+ */
+bool io_pool_alloc_blob(struct connection_struct *conn,
+			size_t buflen,
+			DATA_BLOB *out);
+
+void *_io_pool_calloc_size(struct connection_struct *conn, size_t size,
+			   const char *name, const char *location);
+
+/**
+ * @brief Allocate a specified amount of zero-initialized memory with the
+ *	  specified name using the io_memory_pool.
+ *
+ * @param[in]	conn		The current tree connection
+ * @param[in]	size		size of allocation
+ * @param[in]	name 		Name to use for new talloc chunk
+ *
+ * @return	Pointer to new talloc chunk, NULL on error.
+ */
+#define io_pool_calloc_size(conn, size, name)\
+	_io_pool_calloc_size(conn, size, name, __location__)
+
+/**
+ * @brief Allocate a zero-initialized memory chunk of the specified
+ * 	  type.
+ *
+ * @param[in]	conn		The current tree connection
+ * @param[in]	type		Type of memory to allocate
+ *
+ * @return	Pointer to new talloc chunk, NULL on error.
+ */
+#define io_pool_calloc(conn, type)\
+	(type *)io_pool_calloc_size(conn, sizeof(type), #type)

--- a/source3/smbd/globals.h
+++ b/source3/smbd/globals.h
@@ -914,6 +914,8 @@ struct smbd_server_connection {
 	struct pthreadpool_tevent *pool;
 
 	struct smbXsrv_client *client;
+
+	TALLOC_CTX *io_memory_pool;
 };
 
 extern struct smbXsrv_client *global_smbXsrv_client;

--- a/source3/smbd/smb2_aio.c
+++ b/source3/smbd/smb2_aio.c
@@ -23,6 +23,7 @@
 #include "smbd/globals.h"
 #include "../lib/util/tevent_ntstatus.h"
 #include "../lib/util/tevent_unix.h"
+#include "source3/lib/truenas_mempool.h"
 
 /****************************************************************************
  Accessor function to return write_through state.
@@ -354,8 +355,8 @@ NTSTATUS schedule_smb2_aio_read(connection_struct *conn,
 	}
 
 	/* Create the out buffer. */
-	*preadbuf = data_blob_talloc(ctx, NULL, smb_maxcnt);
-	if (preadbuf->data == NULL) {
+
+	if (!io_pool_alloc_blob(conn, smb_maxcnt, preadbuf)) {
 		return NT_STATUS_NO_MEMORY;
 	}
 

--- a/source3/wscript_build
+++ b/source3/wscript_build
@@ -753,6 +753,7 @@ bld.SAMBA3_LIBRARY('smbd_base',
                         GNUTLS_HELPERS
                         fd_handle
                         cli_spoolss
+                        TRUENAS_MEMPOOL
                    ''' +
                    bld.env['dmapi_lib'] +
                    bld.env['legacy_quota_libs'] +
@@ -1141,6 +1142,16 @@ bld.SAMBA3_BINARY('smbd/smbd',
 bld.SAMBA3_SUBSYSTEM('TDB_VALIDATE',
                      source='lib/tdb_validate.c',
                      deps='samba-util')
+
+
+bld.SAMBA3_SUBSYSTEM('TRUENAS_MEMPOOL',
+                     source='lib/truenas_mempool.c',
+                     deps='''
+                          samba-util
+                          talloc
+                          tevent
+                          ''')
+
 
 bld.SAMBA3_SUBSYSTEM('util_sd',
                      deps='smbclient',


### PR DESCRIPTION
During performance investigations it was determined that a significant amount of CPU time was spent in asm_exc_page_fault and sbrk due to need to constantly allocate and free IO buffers.

This commit adds the ability for us to allocate a memory pool to use for these large allocations. In future revisions the pool will be used in other areas where we are frequently allocating and freeing memory.

The memory pool is lazy-initialized as client begins performing AIO reads from the server. Once it is initialized a timer is set to check our allocation count and if there are no outstanding allocations for two rounds of checks, then we will free the pool. This is to reduce memory footprint of idle smbd processes.