### PR TITLE
NAS-127869 / hardcode passdb.tdb path

### DIFF
--- a/source3/passdb/pdb_tdb.c
+++ b/source3/passdb/pdb_tdb.c
@@ -56,6 +56,8 @@ static int tdbsam_debug_level = DBGC_ALL;
 #define RIDPREFIX		"RID_"
 #define PRIVPREFIX		"PRIV_"
 #define NEXT_RID_STRING		"NEXT_RID"
+#define TRUENAS_PRIVATE_DIR	"/var/run/samba-cache/private/"
+#define TRUENAS_PASSDB		TRUENAS_PRIVATE_DIR PASSDB_FILE_NAME
 
 /* GLOBAL TDB SAM CONTEXT */
 
@@ -1340,8 +1342,8 @@ static NTSTATUS pdb_init_tdbsam(struct pdb_methods **pdb_method, const char *loc
 	/* save the path for later */
 
 	if (!location) {
-		if (asprintf(&tdbfile, "%s/%s", lp_private_dir(),
-			     PASSDB_FILE_NAME) < 0) {
+		tdbfile = strdup(TRUENAS_PASSDB);
+		if (tdbfile == NULL) {
 			return NT_STATUS_NO_MEMORY;
 		}
 		pfile = tdbfile;


### PR DESCRIPTION
TrueNAS stores samba's passdb.tdb in a separate path than the normal private directory (in our case /var/db/system/samba4/private. The passdb path can normally be overriden by manually specifying the full path, e.g. "passdb backend = tdbsam:/var/run/samba-cache/private/passdb.tdb" but this has proven to be somewhat unreliable in cases where the samba registry is being actively modified. The practical impact is that there are some difficult-to-reproduce circumstances when the winbind idmap daemon may end up with a handle on a passdb file in the wrong path. Since we are the only consumers for this samba version, it is safe to simply hard-code the passdb path to what we expect.