### PR TITLE
NAS-128410 / 24.04 / Fix logic for checking whether to create default…

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -784,7 +784,19 @@ static zfsacl_t fsp_get_zfsacl_from_mode(struct files_struct *fsp)
 		return NULL;
 	}
 
-	ASSERT_CTL_INO(st.st_ino);
+	if ((st.st_ino != ZFSCTL_INO_ROOT) && (st.st_ino != ZFSCTL_INO_SNAPDIR)) {
+		SMB_ASSERT(S_ISDIR(st.st_mode));
+
+		struct stat parent;
+		error = fstatat(fsp_get_pathref_fd(fsp), "..", &parent, 0);
+		if (error) {
+			DBG_ERR("%s: failed to stat parent directory", fsp_str_dbg(fsp));
+			errno = EACCES;
+			return NULL;
+		}
+
+		ASSERT_CTL_INO(parent.st_ino);
+	}
 
 	zfsacl = zfsacl_init(ZFSACL_MAX_ENTRIES, ZFSACL_BRAND_NFSV4);
 	if (zfsacl == NULL) {


### PR DESCRIPTION
… ACL (#383)

This commit fixes inode number checks on files that lack an NFSv4 ACL.

Allow synthetic ACL in the following situations:
1. inode is for zfs ctldir root
2. inode is for zfs snapdir root
3. file is directory and parent dir is snapdir root

All other cases SMB_ASSERT since we expect all other files to have an ACL.