### PR TITLE
Increase StartLimitBurst for smbd systemd unit

### DIFF
--- a/packaging/systemd/smb.service.in
+++ b/packaging/systemd/smb.service.in
@@ -4,6 +4,7 @@ Documentation=man:smbd(8) man:samba(7) man:smb.conf(5)
 Wants=network-online.target
 After=network.target network-online.target nmb.service winbind.service
 Requires=winbind.service
+StartLimitBurst=10
 
 [Service]
 Type=notify


### PR DESCRIPTION
During some HA failover testing it was observed that various hooks in dragonfish could cause SMB process to exceed the default start busrst limit in systemd. This commit eases the limit slightly.