### PR TITLE
NAS-128615 / Revert workaround for rpc_lsad bug in older samba versions

### DIFF
--- a/source3/winbindd/winbindd_getgrgid.c
+++ b/source3/winbindd/winbindd_getgrgid.c
@@ -20,7 +20,6 @@
 #include "includes.h"
 #include "winbindd.h"
 #include "libcli/security/dom_sid.h"
-#include "passdb/machine_sid.h"
 
 struct winbindd_getgrgid_state {
 	struct tevent_context *ev;
@@ -81,8 +80,7 @@ static void winbindd_getgrgid_gid2sid_done(struct tevent_req *subreq)
 	if (tevent_req_nterror(req, status)) {
 		return;
 	}
-	if (is_null_sid(state->sid) ||
-	    (dom_sid_compare_domain(state->sid, get_global_sam_sid()) == 0)) {
+	if (is_null_sid(state->sid)) {
 		tevent_req_nterror(req, NT_STATUS_NO_SUCH_GROUP);
 		return;
 	}

--- a/source3/winbindd/winbindd_getpwuid.c
+++ b/source3/winbindd/winbindd_getpwuid.c
@@ -20,7 +20,6 @@
 #include "includes.h"
 #include "winbindd.h"
 #include "libcli/security/dom_sid.h"
-#include "passdb/machine_sid.h"
 
 struct winbindd_getpwuid_state {
 	struct tevent_context *ev;
@@ -79,8 +78,7 @@ static void winbindd_getpwuid_uid2sid_done(struct tevent_req *subreq)
 		D_WARNING("Failed with %s.\n", nt_errstr(status));
 		return;
 	}
-	if (is_null_sid(state->sid) ||
-	    (dom_sid_compare_domain(state->sid, get_global_sam_sid()) == 0)) {
+	if (is_null_sid(state->sid)) {
 		tevent_req_nterror(req, NT_STATUS_NO_SUCH_USER);
 		D_WARNING("Failed with NT_STATUS_NO_SUCH_USER.\n");
 		return;


### PR DESCRIPTION


In some earlier versions of SCALE we were having constant lookups via NSS for non-existent users and groups from our apps implementation. This could trigger a winbind recursion bug as well as cause unexpected winbindd load. The work around was to short-circuit nss_winbind for requests for local users and groups and fail with NOT_FOUND.