### PR TITLE
NAS-130359 / Disable TrueNAS auditing framework on FreeBSD

### DIFF
--- a/auth/auth_log.c
+++ b/auth/auth_log.c
@@ -1312,6 +1312,7 @@ void log_authentication_event(
 					      debug_level);
 	}
 
+#ifndef FREEBSD
 	truenas_audit_authentication_event(msg_ctx,
 					      lp_ctx,
 					      start_time,
@@ -1324,6 +1325,7 @@ void log_authentication_event(
 					      server_audit_info,
 					      event_id,
 					      debug_level);
+#endif
 }
 
 /*


### PR DESCRIPTION
We don't provide this feature on core and so we can simply not build it.