### PR TITLE
NAS-130488 / Truncate list of snapshots to a maximum of 512

### DIFF
--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -35,6 +35,7 @@
 #define GMT_NAME_LEN 24 /* length of a @GMT- name */
 
 #define SHADOW_COPY_ZFS_SNAP_DIR ".zfs/snapshot"
+#define MAX_SNAPSHOT_COUNT 512
 
 /*
  * This module does the following:
@@ -1337,7 +1338,7 @@ static int shadow_copy_zfs_get_shadow_copy_zfs_data(vfs_handle_struct *handle,
 		mpoffset = handle->conn->connectpath + mplen + 1;
 	}
 
-	for (entry = snapshots->entries; entry; entry = entry->next) {
+	for (entry = snapshots->entries; entry && idx < MAX_SNAPSHOT_COUNT; entry = entry->next) {
 		/*
 		 * Directories should always be added if they exist in the
 		 * snapshot. Files only be added if mtime differs.


### PR DESCRIPTION
Some VSS clients do not respond well to large numbers of snapshot options being returned from the server. This limits the maximum that we'll send in FSCTL response to 512 which is documented limit for Windows 7 clients. This is not overly bad since we already perform some checks to determine whether snapshot is relevant (contains changed data) before adding to array in case of directories with an additional check of file metadata for regular files.