### PR TITLE
Increase maximum supported ACEs for SMB to ZFS maximum (#401)

### DIFF
--- a/lib/zfsacl/zfsacl.h
+++ b/lib/zfsacl/zfsacl.h
@@ -65,7 +65,7 @@ typedef unsigned int zfsacl_aclflags_t;
 
 #define ZFSACL_UNDEFINED_ID	((uid_t)-1)
 #define ZFSACL_APPEND_ENTRY	-1
-#define ZFSACL_MAX_ENTRIES	64
+#define ZFSACL_MAX_ENTRIES	1024
 
 bool zfsacl_set_fd(int _fd, zfsacl_t _acl);
 bool zfsacl_set_file(const char *_path_p, zfsacl_t _acl);


### PR DESCRIPTION
ZFS internally supports up to 1024 ACEs. We can increase maximum supported in our VFS modules up to this count. It should not create compatiblity problems with Windows clients since that platform supports up to approximately 1700 ACEs.