### PR TITLE
Add expired error

### DIFF
--- a/nsswitch/pam_tdb.c
+++ b/nsswitch/pam_tdb.c
@@ -947,7 +947,7 @@ static int tdb_auth_request(struct ptdb_context *ctx,
 				PAM_TDB_LOG(ctx->pamh, LOG_INFO,
 					    "%s: entry is expired",
 					    user);
-				return PAM_AUTH_ERR;
+				return PAM_CRED_EXPIRED;
 			}
 		}
 		*username_ret = talloc_strdup(ctx, user);


### PR DESCRIPTION
If API key is expired, return PAM_CRED_EXPIRED to differentiate from an account that is simply expired.