### PR TITLE
Fix auditing crash in CREATE request that specify secdesc (#413)

### DIFF
--- a/source3/libsmbjson/js_utils.h
+++ b/source3/libsmbjson/js_utils.h
@@ -15,7 +15,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ___JS_UTILS_H
+#ifndef __JS_UTILS_H
 #define __JS_UTILS_H
 
 /**

--- a/source3/modules/vfs_truenas_audit.h
+++ b/source3/modules/vfs_truenas_audit.h
@@ -296,7 +296,7 @@ bool tn_add_create_payload(struct smb_filename *smb_fname,
 			   uint32_t create_disposition,
 			   uint32_t create_options,
 			   uint32_t file_attributes,
-			   struct security_descriptor *psd,
+			   const char *sddl_str,
 			   struct json_object *jsobj);
 
 /**


### PR DESCRIPTION
This commit changes workflow for generating the SDDL string for the requested ACL so that it occurs before we call the next VFS module. This ensures that any changes further in VFS stack do not impact the auditing module and helps to ensure we log the correct ACL.