### PR TITLE
NAS-131445 / Fix handling for NULL and Empty DACLs in vfs_ixnas (#415)

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -410,10 +410,10 @@ typedef union unid_t {
 } unid_t;
 
 enum acl_brand {
-        SMB_ACL_BRAND_POSIX,
-        SMB_ACL_BRAND_NFS40,
-        SMB_ACL_BRAND_NFS41,
-        SMB_ACL_BRAND_NONE,
+	TRUENAS_ACL_BRAND_UNKNOWN,
+	TRUENAS_ACL_BRAND_POSIX,
+	TRUENAS_ACL_BRAND_NFS4,
+	TRUENAS_ACL_BRAND_NONE,
 };
 
 struct fd_handle;


### PR DESCRIPTION
In some cases SMB clients may explicitly set a security descriptor with a NULL DACL or one that contains no entries.

Per Microsoft documentation a NULL DACL grants full access to any user that requests it; normal secuurty checking is not performed with respect to the file.

An empty DACL is a properly allocated and initialized DACL that contains no access control entries. An empty DACL grants no access to the object it is assigned to.

Both of these DACL variants are edge-case scenarios that can't be handled by Samba's generic NFSv4 ACL backend since the way in which these situations are handled is filesystem-specific. ZFS does not permit setting either empty or null ACLs and so this commit adds special behavior ACL entries to simulate both situations.

NULL DACL: a NULL DACL is written as an ACL contianing a single entry granting everyone@ full control. Inheritance is disabled.

Empty DACL: an empty DACL is written as an ACL containing a single entry granting everyone@ _no_ permissions. Ineritance is disabled.

The single entry can be used for these purposes because historically vfs_ixnas has always inserted an additional hidden ACE to lock down chmod behavior, which means that all normally formed ACLs contain at least two access control entries.