### PR TITLE
Fix management of AIO read buffers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+samba (2:4.20.5+ix-1) unstable; urgency=medium
+
+  * Change memory context for read buffer allocations
+
+ -- Andrew Walker <awalker@ixsystems.com>  Wed, 09 Oct 2024 17:00:00 +0000
+
+
 samba (2:4.20.5+ix-0) unstable; urgency=medium
 
   * Update to Samba 4.20.5

--- a/source3/lib/truenas_mempool.c
+++ b/source3/lib/truenas_mempool.c
@@ -31,7 +31,7 @@ static uint alloc_cnt;
 static struct tevent_timer *io_buffer_timer;
 static struct timespec last_alloc;
 
-struct io_pool_link { uint8_t *to_free; };
+struct io_pool_link { DATA_BLOB to_free; };
 
 static int io_buffer_destroy(struct io_pool_link *lnk)
 {
@@ -44,9 +44,7 @@ static int io_buffer_destroy(struct io_pool_link *lnk)
 	 * to allow a mechanism to effectively reparent the buffer under
 	 * a different memory context.
 	 */
-	if (lnk->to_free) {
-		TALLOC_FREE(lnk->to_free);
-	}
+	data_blob_free(&lnk->to_free);
 	SMB_ASSERT(alloc_cnt > 0);
 	alloc_cnt -= 1;
 	return 0;
@@ -62,7 +60,7 @@ static struct io_pool_link *link_io_buffer_blob(TALLOC_CTX *mem_ctx, DATA_BLOB *
 	if (lnk == NULL) {
 		return lnk;
 	}
-	lnk->to_free = buf->data;
+	lnk->to_free = *buf;
 	talloc_set_destructor(lnk, io_buffer_destroy);
 	return lnk;
 }
@@ -148,48 +146,27 @@ bool io_pool_alloc_blob(struct connection_struct *conn,
 	DATA_BLOB buf = { 0 };
 	struct io_pool_link *lnk = NULL;
 
+	alloc_cnt += 1;
+
 	if (!init_io_pool(conn->sconn)) {
+		alloc_cnt -= 1;
 		return false;
 	}
 
 	buf = data_blob_talloc(conn->sconn->io_memory_pool, NULL, buflen);
 	if (buf.data == NULL) {
+		alloc_cnt -= 1;
 		return false;
 	}
 
 	lnk = link_io_buffer_blob(mem_ctx, &buf);
 	if (lnk == NULL) {
 		data_blob_free(&buf);
+		alloc_cnt -= 1;
 		return false;
 	}
 
-	*out = buf;
+	*out = lnk->to_free;
 	*lnk_out = lnk;
-	alloc_cnt += 1;
 	return true;
-}
-
-void *_io_pool_calloc_size(struct connection_struct *conn, size_t size,
-			   const char *name, const char *location)
-{
-	void *out = NULL;
-
-	if (!init_io_pool(conn->sconn)) {
-		return NULL;
-	}
-
-	out = talloc_zero_size(conn, size);
-	if (out == NULL) {
-		return NULL;
-	}
-
-	talloc_set_name_const(out, name ? name : location);
-	alloc_cnt += 1;
-
-	if (!link_io_buffer(out)) {
-		TALLOC_FREE(out);
-		return NULL;
-	}
-
-	return out;
 }

--- a/source3/lib/truenas_mempool.h
+++ b/source3/lib/truenas_mempool.h
@@ -38,31 +38,3 @@ bool io_pool_alloc_blob(struct connection_struct *conn,
 			size_t buflen,
 			DATA_BLOB *out,
 			struct io_pool_link **lnk_out);
-
-void *_io_pool_calloc_size(struct connection_struct *conn, size_t size,
-			   const char *name, const char *location);
-
-/**
- * @brief Allocate a specified amount of zero-initialized memory with the
- *	  specified name using the io_memory_pool.
- *
- * @param[in]	conn		The current tree connection
- * @param[in]	size		size of allocation
- * @param[in]	name 		Name to use for new talloc chunk
- *
- * @return	Pointer to new talloc chunk, NULL on error.
- */
-#define io_pool_calloc_size(conn, size, name)\
-	_io_pool_calloc_size(conn, size, name, __location__)
-
-/**
- * @brief Allocate a zero-initialized memory chunk of the specified
- * 	  type.
- *
- * @param[in]	conn		The current tree connection
- * @param[in]	type		Type of memory to allocate
- *
- * @return	Pointer to new talloc chunk, NULL on error.
- */
-#define io_pool_calloc(conn, type)\
-	(type *)io_pool_calloc_size(conn, sizeof(type), #type)

--- a/source3/smbd/smb2_aio.c
+++ b/source3/smbd/smb2_aio.c
@@ -357,7 +357,7 @@ NTSTATUS schedule_smb2_aio_read(connection_struct *conn,
 
 	/* Create the out buffer. */
 
-	if (!io_pool_alloc_blob(conn, ctx, smb_maxcnt, preadbuf, &lnk)) {
+	if (!io_pool_alloc_blob(conn, smbreq->smb2req, smb_maxcnt, preadbuf, &lnk)) {
 		return NT_STATUS_NO_MEMORY;
 	}
 

--- a/source3/smbd/smb2_read.c
+++ b/source3/smbd/smb2_read.c
@@ -594,7 +594,7 @@ static struct tevent_req *smbd_smb2_read_send(TALLOC_CTX *mem_ctx,
 	}
 
 	/* Ok, read into memory. Allocate the out buffer. */
-	if (!io_pool_alloc_blob(fsp->conn, state, in_length, &state->out_data,
+	if (!io_pool_alloc_blob(fsp->conn, smb2req, in_length, &state->out_data,
 				&state->io_lnk)) {
 		tevent_req_nomem(NULL, req);
 		return tevent_req_post(req, ev);


### PR DESCRIPTION
Freeing an AIO read buffer while it is in-use by io_uring may trigger a server reboot. This commit changes the memory context to which AIO read buffers are linked from a nested AIO read state to the originating smb2 request. This is a longer-lived talloc context that avoids issues in error handling that may result in freeing the the AIO read state while the buffer is in-use. This matches allocation behavior for struct aio_extra.

The issue was not observed in earlier versions of TrueNAS before the TrueNAS memory pool was introduced (23.10 and earlier) due to different io_uring behavior in earlier kernels than DragonFish where reads were being performed synchronously by io_uring.