### PR TITLE
smb_libzfs: fix check for bclone enabled

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -1915,7 +1915,8 @@ smb_zfs_pool_feature_enabled(struct zfs_dataset *ds,
 		return false;
 	}
 
-	if (strcmp(statebuf, "enabled") == 0) {
+	if ((strcmp(statebuf, "enabled") == 0) ||
+	    (strcmp(statebuf, "active") == 0)) {
 		*enabled_out = true;
 
 	} else {


### PR DESCRIPTION
It appears that there may be some variation between how the feature's status is reported to userspace. Flag block cloning as enabled if feature status is "active".