### PR TITLE
Boost maximum valid pwrite range to 64 TiB

### DIFF
--- a/source3/smbd/vfs.c
+++ b/source3/smbd/vfs.c
@@ -427,8 +427,13 @@ bool vfs_valid_pwrite_range(off_t offset, size_t length)
 {
 	/*
 	 * See MAXFILESIZE in [MS-FSA] 2.1.5.3 Server Requests a Write
+	 *
+	 * Packet captures on ReFS showed successful writes to offsets
+	 * greater than MAXFILESIZE in MS-FSA and so we boost this to
+	 * 64 TiB which seems like a reasonable upper-bound for VEEAM
+	 * workloads.
 	 */
-	static const uint64_t maxfilesize = 0xfffffff0000;
+	static const uint64_t maxfilesize = 0x0000400000000000;
 	uint64_t last_byte_ofs;
 	bool ok;
 


### PR DESCRIPTION
Packet captures from Windows server shows that writes to large offsets / large files is permitted over SMB protocol to ReFS backed SMB shares and so we should do the same.