### PR TITLE
NAS-132685 / Fix memory context for IPC read allocations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+samba (2:4.20.5+ix-2) unstable; urgency=medium
+
+ * Fix memory context for IPC read allocations
+
+ -- Andrew Walker <awalker@ixsystems.com>  Fri, 22 Nov 2024 17:00:00 +0000
+
+
 samba (2:4.20.5+ix-1) unstable; urgency=medium
 
   * Change memory context for read buffer allocations

--- a/source3/smbd/smb2_read.c
+++ b/source3/smbd/smb2_read.c
@@ -498,8 +498,9 @@ static struct tevent_req *smbd_smb2_read_send(TALLOC_CTX *mem_ctx,
 		struct tevent_req *subreq = NULL;
 		bool ok;
 
-		state->out_data = data_blob_talloc(state, NULL, in_length);
-		if (in_length > 0 && tevent_req_nomem(state->out_data.data, req)) {
+		if (!io_pool_alloc_blob(fsp->conn, smb2req, in_length, &state->out_data,
+					&state->io_lnk)) {
+			tevent_req_nomem(NULL, req);
 			return tevent_req_post(req, ev);
 		}
 


### PR DESCRIPTION
Allocate buffer out of our memory pool and ensure that it's allocated against a longer-lived TALLOC context to prevent potential for UAF.