### PR TITLE
NAS-133278 / Fix NULL dereference when generating log message

### DIFF
--- a/source3/lib/adouble.c
+++ b/source3/lib/adouble.c
@@ -2166,10 +2166,9 @@ static ssize_t ad_read_meta(vfs_handle_struct *handle,
 	ok = ad_unpack(ad, ADEID_NUM_XATTR, AD_DATASZ_XATTR);
 	if (!ok) {
 		DBG_WARNING(
-			"Invalid AppleDouble xattr metadata (%s) in file: %s - "
+			"Invalid AppleDouble xattr metadata in file: %s - "
 			"Consider deleting the corrupted file.\n",
-			smb_fname->base_name,
-			ad->ad_fsp->fsp_name->base_name);
+			smb_fname->base_name);
 		errno = EINVAL;
 		rc = -1;
 		goto exit;


### PR DESCRIPTION
ad->ad_fsp is always NULL for metadata xattrs when in netatalk compatibility mode.