### PR TITLE
NAS-133063 / Always uppercase WS-Discovery hostname

### DIFF
--- a/source3/script/wsdd.py
+++ b/source3/script/wsdd.py
@@ -853,10 +853,7 @@ class WSDHttpMessageHandler(WSDMessageHandler):
 
         fmt = '{0}/Domain:{1}' if args.domain else '{0}/Workgroup:{1}'
         value = args.domain if args.domain else args.workgroup.upper()
-        if args.domain:
-            dh = args.hostname if args.preserve_case else args.hostname.lower()
-        else:
-            dh = args.hostname if args.preserve_case else args.hostname.upper()
+        dh = args.hostname if args.preserve_case else args.hostname.upper()
 
         ElementTree.SubElement(host, PUB_COMPUTER).text = fmt.format(dh, value)
 


### PR DESCRIPTION
For reference on why this change should be made IMO, see JIRA ticket [NAS-133063](https://ixsystems.atlassian.net/browse/NAS-133063).

TL;DR is that this follows Windows (Server) behavior and stops changing the capitalization from uppercase to lowercase after joining a domain. With this change, it'll also always be uppercase now.

The patch was tested and works as expected, but if you want this to be changed in a different way, let me know.

---

This is **NOT** a breaking change, as this only affects discovery. Both `\\SERVER` and `\\server` paths are valid, but WS-Discovery generally uses uppercase names and the discovered name shouldn't change capitalization depending on whether the TrueNAS Scale machine is joined to a domain or not. Windows always uses uppercase.

And some reference pictures from how a Windows machine sees the NETBIOS name advertised via WS-Discovery:
- TrueNAS Scale machine before the change when joined to a domain:
![Bildschirmfoto 2025-01-03 um 21 52 33](https://github.com/user-attachments/assets/7e3d6f82-a87f-42ca-a619-6aa458cd7a5a)
- TrueNAS Scale machine after the change when joined to a domain OR when not joined to a domain OR how a Windows (Server) machine is shown:
![Bildschirmfoto 2025-01-03 um 21 57 13](https://github.com/user-attachments/assets/693e5857-a5fc-4732-924c-c04af03f238c)

(cc @anodos325 for feedback if you have some spare time, as you worked on WS-Discovery before and also have the JIRA ticket assigned)