### PR TITLE
Add handling for DISABLED ZFS snapdir (#447)

### DIFF
--- a/source3/modules/smb_libzfs.c
+++ b/source3/modules/smb_libzfs.c
@@ -621,7 +621,7 @@ static struct zfs_dataset *copy_to_external(TALLOC_CTX *mem_ctx,
 		out->properties->readonly = prop_in->readonly;
 		out->properties->record_size = prop_in->record_size;
 		out->properties->checksum_enabled = prop_in->checksum_enabled;
-		out->properties->snapdir_visible = prop_in->snapdir_visible;
+		out->properties->snapdir = prop_in->snapdir;
 	}
 	if (open_zhandle) {
 		out->zhandle = smbzhandle_dup(out, ds_in->ds->zhandle);
@@ -1211,9 +1211,11 @@ zhandle_get_props(struct smbzhandle *zfsp_ext,
 		return -1;
 	}
 	if (strcmp(buf, "visible") == 0) {
-		props->snapdir_visible = true;
+		props->snapdir = SMBZFS_SNAPDIR_VISIBLE;
+	} else if (strcmp(buf, "disabled") == 0) {
+		props->snapdir = SMBZFS_SNAPDIR_DISABLED;
 	} else {
-		props->snapdir_visible = false;
+		props->snapdir = SMBZFS_SNAPDIR_HIDDEN;
 	}
 
 	if (zfs_prop_get(zfsp, ZFS_PROP_CHECKSUM,

--- a/source3/modules/smb_libzfs.h
+++ b/source3/modules/smb_libzfs.h
@@ -76,6 +76,12 @@ enum zfs_quotatype {
 	SMBZFS_GROUP_QUOTA,
 };
 
+enum zfs_snapdir_type {
+	SMBZFS_SNAPDIR_HIDDEN,
+	SMBZFS_SNAPDIR_VISIBLE,
+	SMBZFS_SNAPDIR_DISABLED
+};
+
 enum zfs_feature {SMBZFS_BLOCK_CLONING};
 
 struct zfs_quota {
@@ -89,8 +95,8 @@ struct zfs_quota {
 struct zfs_dataset_prop
 {
 	enum casesensitivity casesens;
+	enum zfs_snapdir_type snapdir;
 	bool readonly;
-	bool snapdir_visible;
 	bool checksum_enabled;
 	uint64_t record_size;
 #if 0 /* Properties we may wish to expose in the future */

--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -474,7 +474,7 @@ static bool shadow_copy_zfs_update_snaplist(struct vfs_handle_struct *handle,
 	} else {
 		ds = shadow_fsp_to_dataset(handle, config, fsp);
 	}
-	if (!ds || ds->properties->snapdir_visible) {
+	if (!ds || (ds->properties->snapdir != SMBZFS_SNAPDIR_HIDDEN)) {
 		*snapp = NULL;
 		return false;
 	}


### PR DESCRIPTION
OpenZFS 2.3 added a new "disabled" option for the ZFS snapdir. This commit ensures that shadow_copy_zfs and smblibzfs account the property.