### PR TITLE
NAS-134666 protect against NULL deref in lease break

### DIFF
--- a/source3/smbd/smb2_setinfo.c
+++ b/source3/smbd/smb2_setinfo.c
@@ -199,12 +199,14 @@ static bool delay_rename_lease_break_fn(
 	uint32_t e_lease_type, break_to;
 	bool ours, stale;
 
-	ours = smb2_lease_equal(fsp_client_guid(fsp),
-				&fsp->lease->lease.lease_key,
-				&e->client_guid,
-				&e->lease_key);
-	if (ours) {
-		return false;
+	if (fsp->lease != NULL) {
+		ours = smb2_lease_equal(fsp_client_guid(fsp),
+					&fsp->lease->lease.lease_key,
+					&e->client_guid,
+					&e->lease_key);
+		if (ours) {
+			return false;
+		}
 	}
 
 	e_lease_type = get_lease_type(e, fsp->file_id);


### PR DESCRIPTION
When preparing to rename a file over the SMB protocol a client may request a rename while not holding an explicit lease on the file. The current leases on other opens of the same file will need to be broken in this case, but we should add a check for fsp->lease == NULL.

```
202	in ../../source3/smbd/smb2_setinfo.c

(gdb) p fsp->lease
$24 = (struct fsp_lease *) 0x0
```