### PR TITLE
NAS-136449 / 25.04.2 / Make FSCTL_SRV_REQUEST_RESUME_KEY sync

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+samba (2:4.21.6+ix-0) unstable; urgency=medium
+
+ * Update to samba 4.21.6
+
+ * Fix server-side copies for MacOS clients
+
+ -- Andrew Walker <awalker@ixsystems.com>  Wed, 25 Jun 2025 17:00:00 +0000
+
+
 samba (2:4.21.3+ix-0) unstable; urgency=medium
 
  * Initial samba 4.21 port

--- a/source3/smbd/smb2_ioctl.c
+++ b/source3/smbd/smb2_ioctl.c
@@ -71,6 +71,7 @@ NTSTATUS smbd_smb2_request_process_ioctl(struct smbd_smb2_request *req)
 	uint32_t data_length_out;
 	uint32_t data_length_tmp;
 	uint32_t data_length_max;
+	uint32_t defer_time = 1000;
 	struct tevent_req *subreq;
 
 	status = smbd_smb2_request_verify_sizes(req, 0x39);
@@ -212,6 +213,8 @@ NTSTATUS smbd_smb2_request_process_ioctl(struct smbd_smb2_request *req)
 				NT_STATUS_INVALID_PARAMETER);
 		}
 		break;
+	case FSCTL_SRV_REQUEST_RESUME_KEY:
+		defer_time = 0;
 	default:
 		in_fsp = file_fsp_smb2(req, in_file_id_persistent,
 				       in_file_id_volatile);
@@ -247,7 +250,7 @@ NTSTATUS smbd_smb2_request_process_ioctl(struct smbd_smb2_request *req)
 
 	tevent_req_set_callback(subreq, smbd_smb2_request_ioctl_done, req);
 
-	return smbd_smb2_request_pending_queue(req, subreq, 1000);
+	return smbd_smb2_request_pending_queue(req, subreq, defer_time);
 }
 
 /*


### PR DESCRIPTION
MacOS clients send a compounded CREATE/IOCTL/CLOSE request for FSCTL_SRV_REQUEST_RESUME_KEY during mount_smbfs in order to determine whether the SMB server supports copy chunk operations. Samba fails the IOCTL request with STATUS_INTERNAL_ERROR because ioctls default to async. Generating an offload token should never block for an appreciable length of time and so the request doesn't need to be deferred. This matches Windows Server behavior and allows MacOS to successfully determine that copy chunk is supported.