### PR TITLE
NAS-136499 / Enable access-based-enumeration by default for ixnas shares

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -699,6 +699,7 @@ typedef struct files_struct {
 #define TCON_FLAG_STREAMS_XATTR		0x02
 #define TCON_FLAG_STREAMS_FILE		0x04
 #define TCON_FLAG_CASE_INSENSTIVE_FS	0x08
+#define TCON_FLAG_TRUENAS_ABE		0x10
 
 struct vuid_cache_entry {
 	struct auth_session_info *session_info;
@@ -922,6 +923,7 @@ struct vfs_aio_state {
 
 #define VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS 1
 #define VFS_OPEN_HOW_WITH_BACKUP_INTENT 2
+#define VFS_OPEN_HOW_TRUENAS_ABE 3
 
 struct vfs_open_how {
 	int flags;

--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -619,7 +619,8 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 	SMB_ASSERT((dirfd != -1) || (smb_fname->base_name[0] == '/'));
 
 	if (how->resolve & ~(VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS |
-			     VFS_OPEN_HOW_WITH_BACKUP_INTENT)) {
+			     VFS_OPEN_HOW_WITH_BACKUP_INTENT |
+			     VFS_OPEN_HOW_TRUENAS_ABE)) {
 		errno = ENOSYS;
 		result = -1;
 		goto out;
@@ -630,7 +631,9 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 #ifdef O_PATH
 	have_opath = true;
 	if (fsp->fsp_flags.is_pathref) {
-		flags |= O_PATH;
+		if ((how->resolve & VFS_OPEN_HOW_TRUENAS_ABE) == 0) {
+			flags |= O_PATH;
+		}
 	}
 	if (flags & O_PATH) {
 		/*
@@ -3539,7 +3542,7 @@ static ssize_t vfswrap_fgetxattr(struct vfs_handle_struct *handle,
 
 	SMB_ASSERT(!fsp_is_alternate_stream(fsp));
 
-	if (!fsp->fsp_flags.is_pathref) {
+	if (fsp_has_read_access(fsp)) {
 		return fgetxattr(fd, name, value, size);
 	}
 
@@ -3859,7 +3862,7 @@ static ssize_t vfswrap_flistxattr(struct vfs_handle_struct *handle, struct files
 
 	SMB_ASSERT(!fsp_is_alternate_stream(fsp));
 
-	if (!fsp->fsp_flags.is_pathref) {
+	if (fsp_has_read_access(fsp)) {
 		return flistxattr(fd, list, size);
 	}
 

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -114,29 +114,36 @@ static int ixnas_pathref_reopen(const files_struct *fsp, int flags)
 	return fd_out;
 }
 
+static int procfs_get_native_dosmode(struct files_struct *fsp, uint64_t *_dosmode)
+{
+	int fd, err;
+
+	fd = ixnas_pathref_reopen(fsp, O_RDONLY);
+	if ((fd == -1) && (errno == EACCES)) {
+		become_root();
+		fd = ixnas_pathref_reopen(fsp, O_RDONLY);
+		unbecome_root();
+	}
+
+	if (fd == -1) {
+		DBG_WARNING("%s: open() failed: %s\n",
+			    fsp_str_dbg(fsp), strerror(errno));
+		return -1;
+	}
+
+	err = ioctl(fd, ZFS_IOC_GETDOSFLAGS, _dosmode);
+	close(fd);
+
+	return err;
+}
+
 static bool ixnas_get_native_dosmode(struct files_struct *fsp, uint64_t *_dosmode)
 {
 	int err;
-	if (!fsp->fsp_flags.is_pathref) {
-		err = ioctl(fsp_get_io_fd(fsp), ZFS_IOC_GETDOSFLAGS, _dosmode);
+	if (fsp_has_read_access(fsp)) {
+		err = ioctl(fsp_get_pathref_fd(fsp), ZFS_IOC_GETDOSFLAGS, _dosmode);
 	} else {
-		int fd;
-
-		fd = ixnas_pathref_reopen(fsp, O_RDONLY);
-		if ((fd == -1) && (errno == EACCES)) {
-			become_root();
-			fd = ixnas_pathref_reopen(fsp, O_RDONLY);
-			unbecome_root();
-		}
-
-		if (fd == -1) {
-			DBG_WARNING("%s: open() failed: %s\n",
-				    fsp_str_dbg(fsp), strerror(errno));
-			return false;
-		}
-
-		err = ioctl(fd, ZFS_IOC_GETDOSFLAGS, _dosmode);
-		close(fd);
+		err = procfs_get_native_dosmode(fsp, _dosmode);
 	}
 	if (err) {
 		DBG_ERR("%s: ioctl() to get dos flags failed: %s\n",
@@ -208,13 +215,7 @@ static NTSTATUS ixnas_fget_dos_attributes(struct vfs_handle_struct *handle,
 		}
 	}
 
-	if (is_named_stream(fsp->fsp_name)) {
-		// Streams don't have separate dos attribute metadata
-		ok = ixnas_get_native_dosmode(fsp->base_fsp, &kern_dosmode);
-	} else {
-		ok = ixnas_get_native_dosmode(fsp, &kern_dosmode);
-	}
-
+	ok = ixnas_get_native_dosmode(metadata_fsp(fsp), &kern_dosmode);
 	if (!ok) {
 		return map_nt_error_from_unix(errno);
 	}
@@ -330,8 +331,8 @@ static zfsacl_t fsp_get_zfsacl(files_struct *fsp)
 	const char *proc_fd_path = NULL;
 	struct sys_proc_fd_path_buf buf;
 
-	if (!fsp->fsp_flags.is_pathref) {
-		return zfsacl_get_fd(fsp_get_io_fd(fsp), ZFSACL_BRAND_NFSV4);
+	if (fsp_has_read_access(fsp)) {
+		return zfsacl_get_fd(fsp_get_pathref_fd(fsp), ZFSACL_BRAND_NFSV4);
 	}
 
 	SMB_ASSERT(fsp->fsp_flags.have_proc_fds);
@@ -877,11 +878,11 @@ static NTSTATUS ixnas_fget_nt_acl(struct vfs_handle_struct *handle,
 				struct ixnas_config_data,
 				return NT_STATUS_INTERNAL_ERROR);
 
-	to_check = fsp->base_fsp ? fsp->base_fsp : fsp;
+	to_check = metadata_fsp(fsp);
 	zfsacl = fsp_get_zfsacl(to_check);
 	if (zfsacl == NULL) {
 		if ((errno == EINVAL) || (errno == EOPNOTSUPP)) {
-			switch (fsp_get_acl_brand(fsp)) {
+			switch (fsp_get_acl_brand(to_check)) {
 			case TRUENAS_ACL_BRAND_POSIX:
 			case TRUENAS_ACL_BRAND_UNKNOWN:
 				status = SMB_VFS_NEXT_FGET_NT_ACL(handle, fsp, security_info, mem_ctx, ppdesc);
@@ -890,7 +891,7 @@ static NTSTATUS ixnas_fget_nt_acl(struct vfs_handle_struct *handle,
 				}
 				return status;
 			case TRUENAS_ACL_BRAND_NONE:
-				zfsacl = fsp_get_zfsacl_from_mode(fsp);
+				zfsacl = fsp_get_zfsacl_from_mode(to_check);
 				if (zfsacl == NULL) {
 					return map_nt_error_from_unix(errno);
 				}
@@ -1480,11 +1481,57 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 				NULL, struct ixnas_config_data,
 				return -1);
 
+	if (lp_parm_bool(SNUM(handle->conn), "ixnas", "truenas_abe", true)) {
+		/*
+		 * The support team requested that ABE be enabled by default
+		 * on NFSv4 ACL shares in order to preserve FreeBSD behavior
+		 * and better align with enterprise customer expectations
+		 */
+		handle->conn->internal_tcon_flags |= TCON_FLAG_TRUENAS_ABE;
+	}
+
 	return 0;
 }
 
+static int ixnas_openat(vfs_handle_struct *handle,
+			const struct files_struct *dirfsp,
+			const struct smb_filename *smb_fname,
+			files_struct *fsp,
+			const struct vfs_open_how *how)
+{
+	int fd;
+	struct vfs_open_how tmp_how = {
+		.flags = how->flags,
+		.mode = how->mode,
+		.resolve = how->resolve | VFS_OPEN_HOW_TRUENAS_ABE
+	};
+
+	if (!fsp->fsp_flags.is_pathref) {
+		return SMB_VFS_NEXT_OPENAT(handle,
+					   dirfsp,
+					   smb_fname,
+					   fsp,
+					   how);
+	}
+
+	fd = SMB_VFS_NEXT_OPENAT(handle, dirfsp, smb_fname, fsp, &tmp_how);
+	if ((fd == -1) && (errno == EACCES)) {
+		// attempt to open pathref fd O_RDONLY failed
+		// this *should* be a relatively rare edge-case
+		return SMB_VFS_NEXT_OPENAT(handle,
+					   dirfsp,
+					   smb_fname,
+					   fsp,
+					   how);
+	}
+
+	return fd;
+}
+
+
 static struct vfs_fn_pointers ixnas_fns = {
 	.connect_fn = ixnas_connect,
+	.openat_fn = ixnas_openat,
 	/* dosmode_enabled */
 	.fget_dos_attributes_fn = ixnas_fget_dos_attributes,
 	.fset_dos_attributes_fn = ixnas_fset_dos_attributes,

--- a/source3/smbd/dir.c
+++ b/source3/smbd/dir.c
@@ -929,6 +929,7 @@ bool is_visible_fsp(struct files_struct *fsp)
 	if (!hide_unreadable &&
 	    !hide_unwriteable &&
 	    !hide_special &&
+	    (fsp->conn->internal_tcon_flags & TCON_FLAG_TRUENAS_ABE) == 0 &&
 	    (hide_new_files_timeout == 0))
 	{
 		return true;
@@ -990,6 +991,22 @@ bool is_visible_fsp(struct files_struct *fsp)
 		double age = timespec_elapsed(&fsp->fsp_name->st.st_ex_mtime);
 
 		if (age < (double)hide_new_files_timeout) {
+			return false;
+		}
+	}
+
+	if (fsp->conn->internal_tcon_flags & TCON_FLAG_TRUENAS_ABE) {
+		/*
+		 * The SMB share connection has the TrueNAS ABE flag
+		 * set. This means we try to do access-based enumeration
+		 * on the filesystem (determined by whether the current
+		 * credentials could open the specified file without
+		 * resorting to O_PATH). If O_PATH was required then
+		 * use lacks read access, and thus file should not be
+		 * visible.
+		 */
+		int status_flags = fsp_get_status_flags(fsp);
+		if (status_flags & O_PATH) {
 			return false;
 		}
 	}

--- a/source3/smbd/fd_handle.c
+++ b/source3/smbd/fd_handle.c
@@ -31,6 +31,7 @@ struct fd_handle {
 	 * NTCREATEX_FLAG_DENY_FCB.
 	 */
 	uint32_t private_options;
+	int status_flags;  /* TrueNAS */
 	uint64_t gen_id;
 };
 
@@ -137,6 +138,7 @@ void fsp_set_fd(struct files_struct *fsp, int fd)
 	 * where the assignment is done is in fd_open(), but some VFS
 	 * modules do it anyway.
 	 */
+	bool fd_changed = fsp->fh->fd != fd;
 
 	SMB_ASSERT(fsp->fh->fd == -1 ||
 		   fsp->fh->fd == fd ||
@@ -144,4 +146,69 @@ void fsp_set_fd(struct files_struct *fsp, int fd)
 		   fd == AT_FDCWD);
 
 	fsp->fh->fd = fd;
+
+	/* TrueNAS changes */
+	if (fd_changed || fsp->fh->status_flags == 0) {
+		if (fsp->fh->fd == -1 || fsp->fh->fd == AT_FDCWD) {
+			fsp->fh->status_flags = 0;
+		} else {
+			fsp->fh->status_flags = fcntl(fd, F_GETFL);
+		}
+	}
+}
+
+/* TrueNAS changes */
+int fsp_get_status_flags(const struct files_struct *fsp)
+{
+	return fsp->fh->status_flags;
+}
+
+/*
+ * There are various places where if the pathref was O_PATH we'd have
+ * to make a call through procfs to perform an operation because the
+ * access mode for the fd is incorrect for the syscall (for example
+ * getxattr, listxattr, reading ACLs). This provides a quick check of
+ * our stored status flags for the fd and replies whether the desired
+ * access will require using the procfd path e.g.
+ * getxattr(/proc/self/fd/<fd>). The use for this is limited in scope
+ * and new usage should be carefully validated.
+ */
+bool fsp_must_use_procfd_path(const struct files_struct *fsp,
+			      int desired_access)
+{
+	int status = fsp_get_status_flags(fsp);
+
+	if (status == 0) {
+		return true;
+	}
+
+	if (desired_access == O_RDONLY) {
+		// Allow O_DIRECTORY to fulfill request for O_RDONLY
+		return status & (O_PATH | O_RDWR | O_WRONLY) == 0;
+
+	}
+
+	return status & desired_access == 0;
+}
+
+/*
+ * This is a check for whether the fd in the fd_handle is suitable
+ * for performing fd-based syscalls that require minimally O_RDONLY
+ * access mode. This is specifically to be used in places where
+ * the VFS would need to perform a path-based syscall through a
+ * procfd path (/proc/self/fd/<fd>) as an optimization to avoid
+ * unnecessary lookups
+ */
+bool fsp_has_read_access(const struct files_struct *fsp)
+{
+	if (!fsp->fsp_flags.is_pathref) {
+		/*
+		 * This is not an O_PATH open and so we can
+		 * use it with fgetxattr, flistxattr, and ioctl
+		 * calls
+		 */
+		return true;
+	}
+
+	return !fsp_must_use_procfd_path(fsp, O_RDONLY);
 }

--- a/source3/smbd/fd_handle.h
+++ b/source3/smbd/fd_handle.h
@@ -46,4 +46,9 @@ int fsp_get_io_fd(const struct files_struct *fsp);
 int fsp_get_pathref_fd(const struct files_struct *fsp);
 void fsp_set_fd(struct files_struct *fsp, int fd);
 
+/* TrueNAS changes */
+int fsp_get_status_flags(const struct files_struct *fsp);
+bool fsp_must_use_procfd_path(const struct files_struct *fsp,
+			      int desired_access);
+bool fsp_has_read_access(const struct *fsp);
 #endif


### PR DESCRIPTION
This commit makes TrueNAS SCALE with NFSv4 acltype match FreeBSD behavior of having access-based-enumeration enabled by default for paths. This is achieved by allowing openat_pathref_fsp_lcomp O_RDONLY flag to pass through to the actual openat access mode via vfs_ixnas. If credential lacks read access to the file then the open is automatically retried with O_PATH.

struct fd_handle is expanded to include the fd status flags (F_GETFL output) so that other areas in the samba vfs can be evalaute and potentially reuse this FD rather than following paradigm of opening a file O_PATH then immediately reopening with O_RDONLY.