### PR TITLE
NAS-136530 / Reintroduce case sensitivity optimization for ZFS

### DIFF
--- a/source3/smbd/filename.c
+++ b/source3/smbd/filename.c
@@ -286,7 +286,11 @@ NTSTATUS get_real_filename_full_scan_at(struct files_struct *dirfsp,
 	 * good to search for a name. If a case variation of the name was
 	 * there, then the original stat(2) would have found it.
 	 */
-	if (!mangled && !(conn->fs_capabilities & FILE_CASE_SENSITIVE_SEARCH)) {
+	/* TrueNAS -- if the ZFS dataset is case-insensitive and name isn't
+	 * mangled it would have been picked up in initial stat(2) as well.
+	 */
+	if (!mangled && (!(conn->fs_capabilities & FILE_CASE_SENSITIVE_SEARCH) ||
+	    (conn->internal_tcon_flags & TCON_FLAG_CASE_INSENSTIVE_FS))) {
 		return NT_STATUS_OBJECT_NAME_NOT_FOUND;
 	}
 

--- a/source3/smbd/files.c
+++ b/source3/smbd/files.c
@@ -927,7 +927,12 @@ static int smb_vfs_openat_ci(TALLOC_CTX *mem_ctx,
 	bool ok;
 
 	fd = SMB_VFS_OPENAT(conn, dirfsp, smb_fname_rel, fsp, how);
-	if ((fd >= 0) || case_sensitive) {
+	/*
+	 * A positive result or ENOENT on case insensitive filesystem is
+	 * authoritative.
+	 */
+	if ((fd >= 0) || case_sensitive ||
+	    (conn->internal_tcon_flags & TCON_FLAG_CASE_INSENSTIVE_FS)) {
 		return fd;
 	}
 	if (errno != ENOENT) {


### PR DESCRIPTION
This commit adds an optimization for situation where ZFS is
case-insensitive. When we're resolving path name for opening a
file and the filesystem is case-insensitve, the initial fstatat
call is authoritative because ZFS lookup will handle
case-insensitive portion.

Originally TrueNAS had an optimization for this situation but
it was removed in NAS-118707 due to the complaint of a potential
customer. This commit commit is more targeted than the old
optimization and doesn't regress the problem with wildcard matches