### PR TITLE
NAS-136652 / Work around broken lsa openpolicy3 in samba 4.20

### DIFF
--- a/source3/rpc_client/cli_lsarpc.c
+++ b/source3/rpc_client/cli_lsarpc.c
@@ -179,6 +179,7 @@ NTSTATUS dcerpc_lsa_open_policy_fallback(struct dcerpc_binding_handle *h,
 {
 	NTSTATUS status;
 
+#if 0
 	status = dcerpc_lsa_open_policy3(h,
 					 mem_ctx,
 					 srv_name_slash,
@@ -195,6 +196,7 @@ NTSTATUS dcerpc_lsa_open_policy_fallback(struct dcerpc_binding_handle *h,
 				.revision = 1,
 			}
 		};
+#endif
 
 		status = dcerpc_lsa_open_policy2(h,
 						 mem_ctx,
@@ -203,7 +205,7 @@ NTSTATUS dcerpc_lsa_open_policy_fallback(struct dcerpc_binding_handle *h,
 						 desired_access,
 						 pol,
 						 result);
-	}
+//	}
 
 	return status;
 }


### PR DESCRIPTION
Samba 4.20 has broken lsa openpolicy3 handling. Windows server rejects the dcerpc_lsa_openpolicy3() call with STATUS_ACCESS_DENIED which terminates the cli session causing the fallthough code to also fail. This results in the domain not being flagged as active directory internally in winbindd. Since it is no longer flagged internally as AD, the new DNS lookup code to convert the short-form name to FQDN also fails causing the fix for idmap_ad to become ineffective because samba /winbindd cannot convert the short-form name of the domain to anything useful (unless it was already cached from an earlier cldap response).

This commit restores Samba 4.19 and earlier behavior regarding lsa_open_policy.