### PR TITLE
NAS-136681 / Fix pam_tdb response for unknown user

### DIFF
--- a/nsswitch/pam_tdb.c
+++ b/nsswitch/pam_tdb.c
@@ -898,6 +898,7 @@ static int tdb_auth_request(struct ptdb_context *ctx,
 				      user);
 
 			pam_ret = PAM_USER_UNKNOWN;
+			break;
 		default:
 			PAM_CTX_DEBUG(ctx, LOG_ERR,
 				      "%s: failed to fetch entry: %d: %s\n",


### PR DESCRIPTION
This commit fixes the PAM response code when an unknown user is referenced in the tdb file.