### PR TITLE
NAS-136710 / Remove unnecessary call to set archive bit

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -1471,6 +1471,10 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 	config->dosattrib_xattr = lp_parm_bool(SNUM(handle->conn),
 			"ixnas", "dosattrib_xattr", false);
 
+	if (!config->dosattrib_xattr) {
+		lp_do_parameter(SNUM(handle->conn), "kernel dosmodes", "yes");
+	}
+
 	ok = set_acl_parameters(handle, config);
 	if (!ok) {
 		TALLOC_FREE(config);

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -3606,7 +3606,8 @@ static void possibly_set_archive(struct connection_struct *conn,
 	bool set_archive = false;
 	int ret;
 
-	if (info == FILE_WAS_OPENED) {
+	// If kernel doesmodes are enabled then ARCHIVE is set by the FS
+	if ((info == FILE_WAS_OPENED) || lp_kernel_dosmodes(SNUM(conn))) {
 		return;
 	}
 
@@ -3614,8 +3615,6 @@ static void possibly_set_archive(struct connection_struct *conn,
 	if ((info == FILE_WAS_OVERWRITTEN && lp_map_archive(SNUM(conn)))) {
 		set_archive = true;
 	} else if (lp_store_dos_attributes(SNUM(conn))) {
-		set_archive = true;
-	} else if (lp_kernel_dosmodes(SNUM(conn))) {
 		set_archive = true;
 	}
 	if (!set_archive) {

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -3606,7 +3606,7 @@ static void possibly_set_archive(struct connection_struct *conn,
 	bool set_archive = false;
 	int ret;
 
-	// If kernel doesmodes are enabled then ARCHIVE is set by the FS
+	// If kernel dosmodes are enabled then ARCHIVE is set by the FS
 	if ((info == FILE_WAS_OPENED) || lp_kernel_dosmodes(SNUM(conn))) {
 		return;
 	}


### PR DESCRIPTION
This commit does two things:
1. It removes one unnecessary call to set the archive bit when creating new files. ZFS automatically does this for us.

2. It ensures that "kernel dosmodes" is always set by vfs_ixnas if the module is enabled with dosmode support.