### PR TITLE
Partially revert dosmode change

### DIFF
--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -3606,8 +3606,7 @@ static void possibly_set_archive(struct connection_struct *conn,
 	bool set_archive = false;
 	int ret;
 
-	// If kernel dosmodes are enabled then ARCHIVE is set by the FS
-	if ((info == FILE_WAS_OPENED) || lp_kernel_dosmodes(SNUM(conn))) {
+	if (info == FILE_WAS_OPENED) {
 		return;
 	}
 


### PR DESCRIPTION
An earlier change related to kernel dos modes caused internal CI tests for setting DOS modes during SMB2_CREATE operations to fail.