### PR TITLE
NAS-137691 / Properly initialize mangle for spotlight RPC server

### DIFF
--- a/source3/rpc_server/rpcd_mdssvc.c
+++ b/source3/rpc_server/rpcd_mdssvc.c
@@ -20,6 +20,7 @@
 #include "rpc_worker.h"
 #include "librpc/gen_ndr/ndr_mdssvc.h"
 #include "librpc/gen_ndr/ndr_mdssvc_scompat.h"
+#include "source3/smbd/proto.h"
 
 static size_t mdssvc_interfaces(
 	const struct ndr_interface_table ***pifaces,
@@ -43,6 +44,7 @@ static NTSTATUS mdssvc_servers(
 	bool ok;
 
 	lp_load_with_shares(get_dyn_CONFIGFILE());
+	mangle_reset_cache();
 
 	ok = posix_locking_init(false);
 	if (!ok) {


### PR DESCRIPTION
This commit initializes the mangle function pointers (global state) in the forked RPC server that handles spotlight requests.