### PR TITLE
NAS-137858 / Fix edge case where O_PATH open fails

### DIFF
--- a/source3/smbd/files.c
+++ b/source3/smbd/files.c
@@ -1588,7 +1588,8 @@ NTSTATUS openat_pathref_fsp_lcomp(struct files_struct *dirfsp,
 			       fsp,
 			       &how);
 
-	if ((fd == -1) && (errno == ENOENT)) {
+	if ((fd == -1) &&
+	    ((errno == ENOENT) || (errno == EACCES) || (errno == EPERM))) {
 		status = map_nt_error_from_unix(errno);
 		DBG_DEBUG("smb_vfs_openat(%s/%s) failed: %s\n",
 			  dirfsp->fsp_name->base_name,


### PR DESCRIPTION
This commit fixes a gap in error handling in an internal samba function that is used to open a pathref (O_PATH) descriptor. Currently, code will return success with a fdhandle fd set to -1 which will eventually percolate up to an SMB_ASSERT if the resulting FSP is used as a dirfsp for a subsequent open.