### PR TITLE
NAS-138259 / 25.10.1 / Fix handling of SMB client request to reopen file

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -923,7 +923,7 @@ struct vfs_aio_state {
 
 #define VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS 1
 #define VFS_OPEN_HOW_WITH_BACKUP_INTENT 2
-#define VFS_OPEN_HOW_TRUENAS_ABE 3
+#define VFS_OPEN_HOW_TRUENAS_ABE 4
 
 struct vfs_open_how {
 	int flags;

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -875,6 +875,16 @@ static int tn_reopen_from_fsp_fast(struct files_struct *fsp,
 {
 	int fd_status;
 
+	if (fsp->dptr != NULL) {
+		// We have request to reopen a files_struct that
+		// has an open DIR. The primary reason why this
+		// would happen is if we're handling QUERY_DIRECTORY
+		// with flag to SMB2_REOPEN. Returning -1 here
+		// will force us to fd_close the fsp (which closes
+		// the DIR), and then reopen it.
+		return -1;
+	}
+
 	if ((old_fd == AT_FDCWD) || (old_fd == -1)) {
 		return -1;
 	}


### PR DESCRIPTION
Per MS-SMB 2.2.33 an SMB2 QUERY_DIRECTORY request may contain the SMB2_REOPEN flag which in samba's VFS should trigger a proper reopen of the file. Due to an optimization in the reopen code, we were not properly reopening in this situation which resulted in the directory position potentially not rewinding to beginning of file. This commit forces a close / reopen if the files_struct contains an initialized dptr_struct.