### PR TITLE
Fix io_uring_vfs_disconnect function (#490)

### DIFF
--- a/source3/modules/vfs_io_uring.c
+++ b/source3/modules/vfs_io_uring.c
@@ -1043,6 +1043,8 @@ static void vfs_io_uring_disconnect(vfs_handle_struct *handle)
 {
 	struct vfs_io_uring_config *config = NULL;
 
+	SMB_VFS_NEXT_DISCONNECT(handle);
+
 	SMB_VFS_HANDLE_GET_DATA(handle, config,
 				struct vfs_io_uring_config,
 				smb_panic(__location__));


### PR DESCRIPTION
This function endpoint was added to provide a logging endpoint for aggregated stats on sync vs async operation in the module. Unfortunately due to an oversight when it was written, walking the samba VFS stack for smb_vfs_disconnect was terminating early causing time machine snapshots to not occur.