### PR TITLE
NAS-138562 / 25.10 / boost effective number of max open files to Core default

### DIFF
--- a/packaging/systemd/smb.service.in
+++ b/packaging/systemd/smb.service.in
@@ -8,9 +8,9 @@ Requires=winbind.service
 [Service]
 Type=notify
 PIDFile=@PIDDIR@/smbd.pid
-LimitNOFILE=16384
+LimitNOFILE=infinity
 EnvironmentFile=-@SYSCONFDIR@/sysconfig/samba
-ExecStart=@SBINDIR@/smbd --foreground --no-process-group $SMBDOPTIONS
+ExecStart=@SBINDIR@/smbd --foreground --no-process-group
 ExecReload=/bin/kill -HUP $MAINPID
 LimitCORE=infinity
 @systemd_smb_extra@

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -285,11 +285,41 @@ static bool lp_set_cmdline_helper(const char *pszParmName, const char *pszParmVa
 static void free_param_opts(struct parmlist_entry **popts);
 
 /**
+ * Get the kernel limit of maximum number of file handles a process can allocate
+ */
+static int procfs_get_max_open_files(void)
+{
+	#define PROCFS_NR_OPEN_PATH "/proc/sys/fs/nr_open"
+	FILE *fp = fopen(PROCFS_NR_OPEN_PATH, "r");
+	int ret, procfs_max = MAX_OPEN_FILES;
+
+	if (fp == NULL) {
+		DBG_ERR(PROCFS_NR_OPEN_PATH "Failed to open procfs path "
+			"in order to read current process max open files. "
+			"Defaulting to MAX_OPEN_FILES (%u): %s", MAX_OPEN_FILES,
+			strerror(errno));
+		return procfs_max;
+	}
+
+	ret = fscanf(fp, "%d", &procfs_max);
+	fclose(fp);
+	if (ret == -1) {
+		DBG_ERR(PROCFS_NR_OPEN_PATH ": failed to parse procfs path. "
+			"Defaulting to MAX_OPEN_FILES (%u): %s", MAX_OPEN_FILES,
+			strerror(errno));
+		return MAX_OPEN_FILES;
+	}
+
+	return procfs_max;
+}
+
+/**
  *  Function to return the default value for the maximum number of open
  *  file descriptors permitted.  This function tries to consult the
  *  kernel-level (sysctl) and ulimit (getrlimit()) values and goes
  *  the smaller of those.
  */
+
 static int max_open_files(void)
 {
 	int sysctl_max = MAX_OPEN_FILES;
@@ -301,6 +331,8 @@ static int max_open_files(void)
 		sysctlbyname("kern.maxfilesperproc", &sysctl_max, &size, NULL,
 			     0);
 	}
+#else
+	sysctl_max = procfs_get_max_open_files();
 #endif
 
 #if (defined(HAVE_GETRLIMIT) && defined(RLIMIT_NOFILE))


### PR DESCRIPTION
There are some ML / CAD workloads that may have clients simultaneously open huge numbers of files. This makes linux behavior similar to FreeBSD by removing the hard-coded limit in the upstream systemd file and the sysctl default. We will default to kernel nr_open limit or if separate rlimit is specified, we will obey that instead.

The total max server-wide open file limit is still based on maximum open file table size of SMB1 protocol (0xFFFF - some fudge factor for named pipes). In future commit we can bump this up for default case where SMB1 is disabled. The effect of this changeset is that basically a single client can open up to 59392 files instead of 16384.