### PR TITLE
NAS-138960 / Reduce logging in native dosmode code (#505)

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -162,8 +162,13 @@ static bool ixnas_set_native_dosmode(struct files_struct *fsp, uint64_t dosmode)
 		int fd;
 		fd = ixnas_pathref_reopen(fsp, O_RDWR);
 		if (fd == -1) {
-			DBG_WARNING("%s: open() failed: %s\n",
-				    fsp_str_dbg(fsp), strerror(errno));
+			if ((errno != EACCES) && (errno != EPERM)) {
+				DBG_WARNING("%s: open() failed: %s\n",
+					    fsp_str_dbg(fsp), strerror(errno));
+			} else {
+				DBG_DEBUG("Setting dosmode failed for %s: %s\n",
+					  fsp_str_dbg(fsp), strerror(errno));
+			}
 			return false;
 		}
 		err = ioctl(fd, ZFS_IOC_SETDOSFLAGS, &dosmode);


### PR DESCRIPTION
This commit drops the debug level of messages related to setting native dosmode if the reason is permissions-related. The call site for this will automatically elevate privileges on this failure and so we safely ignore. The message is still perhaps useful for diagnostic purposes when full debugging is enabled.