### PR TITLE
Add ctdb python bindings

### DIFF
--- a/ctdb/protocol/protocol.h
+++ b/ctdb/protocol/protocol.h
@@ -489,6 +489,7 @@ struct ctdb_dbid {
 #define CTDB_DB_FLAGS_REPLICATED	0x08
 	uint8_t flags;
 };
+#define CTDB_DB_FLAGS_LAST		CTDB_DB_FLAGS_REPLICATED
 
 struct ctdb_dbid_map {
 	uint32_t num;
@@ -730,6 +731,8 @@ struct ctdb_public_ip_list {
 #define NODE_FLAGS_DISABLED		(NODE_FLAGS_UNHEALTHY|NODE_FLAGS_PERMANENTLY_DISABLED)
 #define NODE_FLAGS_INACTIVE		(NODE_FLAGS_DELETED|NODE_FLAGS_DISCONNECTED|NODE_FLAGS_BANNED|NODE_FLAGS_STOPPED)
 
+#define NODE_FLAGS_LAST			NODE_FLAGS_STOPPED
+
 /*
  * Node capabilities
  */
@@ -750,6 +753,8 @@ struct ctdb_public_ip_list {
 #define CTDB_CAP_DEFAULT		(CTDB_CAP_RECMASTER | \
 					 CTDB_CAP_LMASTER   | \
 					 CTDB_CAP_FEATURES)
+
+#define CTDB_CAP_LAST			CTDB_CAP_FRAGMENTED_CONTROLS
 
 struct ctdb_node_and_flags {
 	uint32_t pnn;

--- a/ctdb/pyclient/README.md
+++ b/ctdb/pyclient/README.md
@@ -1,0 +1,481 @@
+# pyctdb - Python CTDB Client Extension
+
+A CPython extension module providing a high-performance interface to CTDB (Cluster Trivial Database) for Python applications.
+
+## Overview
+
+`pyctdb` is a native Python extension written in C that provides direct access to CTDB's client library. It enables Python applications to interact with clustered TDB databases with full support for transactions, batch operations, and cluster management.
+
+### Key Features
+
+- **Native Performance**: Direct C API bindings with minimal overhead
+- **Thread-Safe**: Built-in locking mechanisms for concurrent access
+- **Transaction Support**: Atomic operations with automatic rollback on failure
+- **Batch Operations**: Execute multiple operations under a single transaction
+- **Iterator Support**: Memory-efficient iteration over database records
+- **Cluster Management**: Access to node status, recovery mode, and cluster state
+
+## Architecture
+
+The extension is organized into several components:
+
+- **pyclient_module.c**: Module initialization and global state management
+- **pyclient_client.c**: CTDB client connection and cluster operations
+- **pyclient_db.c**: Database handle management and record operations
+- **pyclient_db_batch.c**: Batch operation support with struct sequence types
+- **pyclient_db_iter.c**: Database iteration implementation
+- **pyclient_error.c**: Exception handling and error reporting
+
+### Module State
+
+The module maintains state for:
+- Custom exception types (`CTDBError`)
+- Struct sequence types (`BatchOp`)
+- Enumeration objects for node status, database flags, and capabilities
+- Global locking state for talloc leak reporting
+
+## Installation
+
+The module is built as part of the Samba build system:
+
+```bash
+cd /path/to/samba
+./configure
+make
+```
+
+The compiled module will be available as `pyctdb.so` in the build output.
+
+## API Reference
+
+### Client Class
+
+The main entry point for CTDB operations.
+
+```python
+from pyctdb import Client
+
+# Create a client connection
+client = Client()
+
+# Access cluster information
+pnn = client.pnn                    # Physical Node Number
+leader = client.leader              # Current cluster leader PNN
+timeout = client.timeout            # Operation timeout (default: 10s)
+client.timeout = 30                 # Set timeout to 30 seconds
+
+# Get cluster status
+status = client.status()
+# Returns: {
+#     'nodemap': [...],
+#     'recovery_mode': 'NORMAL' | 'RECOVERY',
+#     'state': <runstate>,
+#     'leader_pnn': <pnn>
+# }
+
+# Get node map
+nodemap = client.nodemap(refresh=False)
+# Returns list of nodes: [{
+#     'pnn': <int>,
+#     'address': '<ip>:<port>',
+#     'flags': [<flag_strings>],
+#     'this_node': <bool>
+# }, ...]
+
+# Open a database
+db = client.get_db(
+    db_name="mydb",
+    persistent=True,      # Persistent database (default)
+    readonly=False,       # Read-write access (default)
+    replicated=False,     # Not replicated (default)
+    create_ok=False       # Don't create if doesn't exist (default)
+)
+```
+
+#### Client Properties
+
+- `pnn` (int, read-only): Physical node number of this client
+- `leader` (int, read-only): PNN of the current cluster leader
+- `timeout` (int, read/write): Timeout in seconds for operations (1-300)
+
+#### Client Methods
+
+##### `status() -> dict`
+Retrieve comprehensive cluster status including nodemap, recovery mode, run state, and leader.
+
+##### `nodemap(refresh=False) -> list`
+Get the cluster node map. If `refresh=True`, fetches fresh data from the cluster; otherwise returns cached data.
+
+##### `get_db(db_name, persistent=True, readonly=False, replicated=False, create_ok=False) -> CtdbDB`
+Open or create a CTDB database with specified flags.
+
+### CtdbDB Class
+
+Represents an open CTDB database handle.
+
+```python
+# Database properties
+name = db.db_name                   # Database name
+db_id = db.db_id                    # Database ID
+flags = db.db_flags                 # Tuple of flag strings
+
+# Single record operations
+value = db.fetch(key=b'mykey')      # Fetch a record
+db.store(key=b'mykey', value=b'myvalue')  # Store a record
+db.delete(key=b'mykey')             # Delete a record
+
+# Bulk operations
+db.wipe_db()                        # Wipe all records (leader only)
+db.sync_with_tdb_file(
+    tdb_path="/path/to/file.tdb",
+    tdb_flags=0,
+    open_flags=0,
+    mode=0o644
+)  # Synchronize with a TDB file (leader only)
+
+# Iteration
+for key, value in db.iter():
+    print(f"Key: {key}, Value: {value}")
+
+# Batch operations
+from pyctdb import BatchOp
+
+results = db.batch_op([
+    BatchOp('SET', b'key1', b'value1'),
+    BatchOp('SET', b'key2', b'value2'),
+    BatchOp('GET', b'key1', None),
+    BatchOp('DEL', b'key2', None),
+])
+# results = {2: b'value1'}  # Index 2 was the GET operation
+```
+
+#### Database Properties
+
+- `db_name` (str, read-only): Name of the database
+- `db_id` (int, read-only): Unique database identifier
+- `db_flags` (tuple, read-only): Database flags as strings (e.g., `('PERSISTENT', 'REPLICATED')`)
+
+#### Database Methods
+
+##### `fetch(key) -> bytes`
+Fetch a record from the database.
+
+**Raises:**
+- `FileNotFoundError`: Record does not exist
+- `CtdbError`: Operation failed
+
+##### `store(key, value) -> None`
+Store a record in the database.
+
+**Raises:**
+- `CtdbError`: Operation failed
+
+##### `delete(key) -> None`
+Delete a record from the database.
+
+**Raises:**
+- `CtdbError`: Operation failed
+
+##### `wipe_db() -> None`
+Wipe all records from the database. Must be called on the cluster leader.
+
+**Raises:**
+- `ValueError`: Not called on leader
+- `CtdbError`: Operation failed
+
+##### `sync_with_tdb_file(tdb_path, tdb_flags=0, open_flags=0, mode=0o644) -> None`
+Synchronize the CTDB database with a local TDB file. Records in CTDB but not in the file are deleted; records in the file are written to CTDB. Must be called on the cluster leader.
+
+**Raises:**
+- `ValueError`: Not called on leader
+- `CtdbError`: Operation failed or file cannot be opened
+
+##### `iter() -> CtdbDBIterator`
+Create an iterator for the database that yields `(key, value)` tuples.
+
+**Raises:**
+- `ValueError`: Database is not persistent or replicated
+- `CtdbError`: Iteration setup failed
+
+##### `batch_op(operations) -> dict`
+Execute multiple operations atomically under a single transaction. All operations succeed or all fail (rollback).
+
+**Parameters:**
+- `operations`: Iterable of `BatchOp` instances
+
+**Returns:**
+- Dictionary mapping operation index to value for all GET operations
+
+**Raises:**
+- `TypeError`: Operations are not BatchOp instances
+- `ValueError`: Database is not persistent/replicated or invalid operation
+- `CtdbError`: Any operation failed (transaction rolled back)
+
+### BatchOp Type
+
+A struct sequence representing a batch operation.
+
+```python
+from pyctdb import BatchOp
+
+# Create batch operations
+op_set = BatchOp('SET', b'mykey', b'myvalue')
+op_get = BatchOp('GET', b'mykey', None)
+op_del = BatchOp('DEL', b'mykey', None)
+
+# Access fields
+action = op_set.action      # 'SET'
+key = op_set.key           # b'mykey'
+value = op_set.value       # b'myvalue'
+```
+
+#### Fields
+
+- `action` (str): Operation type - `'GET'`, `'SET'`, or `'DEL'`
+- `key` (bytes): Record key
+- `value` (bytes | None): Record value (required for SET, None for GET/DEL)
+
+## Usage Examples
+
+### Basic Database Operations
+
+```python
+from pyctdb import Client
+
+# Connect to CTDB
+client = Client()
+
+# Open a persistent database
+db = client.get_db("myapp", persistent=True, create_ok=True)
+
+# Store some data
+db.store(b'user:1', b'{"name": "Alice", "age": 30}')
+db.store(b'user:2', b'{"name": "Bob", "age": 25}')
+
+# Fetch data
+user1 = db.fetch(b'user:1')
+print(user1)  # b'{"name": "Alice", "age": 30}'
+
+# Delete a record
+db.delete(b'user:2')
+
+# Iterate over all records
+for key, value in db.iter():
+    print(f"{key}: {value}")
+```
+
+### Batch Operations
+
+```python
+from pyctdb import Client, BatchOp
+
+client = Client()
+db = client.get_db("myapp", persistent=True)
+
+# Prepare batch operations
+operations = [
+    BatchOp('SET', b'counter:a', b'1'),
+    BatchOp('SET', b'counter:b', b'2'),
+    BatchOp('SET', b'counter:c', b'3'),
+    BatchOp('GET', b'counter:a', None),
+    BatchOp('GET', b'counter:b', None),
+    BatchOp('DEL', b'counter:c', None),
+]
+
+# Execute atomically
+results = db.batch_op(operations)
+
+# Results contains values from GET operations
+print(results[3])  # b'1' (counter:a)
+print(results[4])  # b'2' (counter:b)
+```
+
+### Cluster Management
+
+```python
+from pyctdb import Client
+
+client = Client()
+
+# Check if this node is the leader
+if client.pnn == client.leader:
+    print("This node is the cluster leader")
+
+# Get cluster status
+status = client.status()
+print(f"Recovery mode: {status['recovery_mode']}")
+print(f"Cluster state: {status['state']}")
+
+# Get node information
+nodemap = client.nodemap(refresh=True)
+for node in nodemap:
+    status_str = "LEADER" if node['pnn'] == client.leader else "MEMBER"
+    flags_str = ", ".join(node['flags']) if node['flags'] else "NONE"
+    print(f"Node {node['pnn']}: {node['address']} [{status_str}] flags: {flags_str}")
+```
+
+### Database Synchronization
+
+```python
+from pyctdb import Client
+
+client = Client()
+db = client.get_db("secrets", persistent=True)
+
+# Synchronize CTDB database with a TDB file
+# (must be run on the cluster leader)
+if client.pnn == client.leader:
+    db.sync_with_tdb_file("/var/lib/samba/private/secrets.tdb")
+    print("Database synchronized")
+else:
+    print("Must run on leader node")
+```
+
+## Error Handling
+
+The module raises custom exceptions for CTDB errors:
+
+```python
+from pyctdb import Client, CTDBError
+
+client = Client()
+db = client.get_db("mydb", persistent=True)
+
+try:
+    value = db.fetch(b'nonexistent')
+except FileNotFoundError:
+    print("Record not found")
+except CTDBError as e:
+    print(f"CTDB error: {e}")
+```
+
+## Thread Safety
+
+The extension is designed to be thread-safe:
+
+- Each client context has its own mutex lock
+- Database operations acquire locks before accessing CTDB
+- The GIL is released during long-running operations
+- Global locking can be enabled for talloc leak reporting
+
+```python
+import threading
+from pyctdb import Client
+
+def worker(thread_id):
+    client = Client()
+    db = client.get_db("shared", persistent=True, create_ok=True)
+    db.store(f'thread:{thread_id}'.encode(), b'data')
+
+threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+```
+
+## Performance Considerations
+
+### Iterator vs. Manual Iteration
+
+The `iter()` method creates a snapshot of keys at iteration start, then fetches values on-demand:
+
+```python
+# Memory-efficient - fetches values as needed
+for key, value in db.iter():
+    process(key, value)
+```
+
+### Batch Operations
+
+Use batch operations for atomic multi-record updates:
+
+```python
+# All operations succeed or all fail
+results = db.batch_op([
+    BatchOp('SET', b'key1', b'val1'),
+    BatchOp('SET', b'key2', b'val2'),
+    # ... many more operations
+])
+```
+
+### Transaction Overhead
+
+Single operations (`fetch`, `store`, `delete`) each run in their own transaction. For multiple operations, use `batch_op` to reduce transaction overhead.
+
+## Module Configuration
+
+### Global Locking
+
+Enable global locking for talloc leak reporting (debugging only):
+
+```python
+import pyctdb
+
+# Enable leak reporting (also enables global locking)
+pyctdb.enable_leak_reporting()
+
+# Check if enabled
+if pyctdb.get_leak_reporting():
+    print("Leak reporting is active")
+
+# Query/set global locking independently
+is_locked = pyctdb.get_global_locking()
+pyctdb.set_global_locking(True)
+```
+
+**Note:** Once leak reporting is enabled, it cannot be disabled for the module.
+
+## Database Types
+
+CTDB supports different database types:
+
+- **Persistent**: Data survives cluster recovery (`persistent=True`)
+- **Volatile**: Data is lost on recovery (`persistent=False`)
+- **Replicated**: Database is replicated across all nodes (`replicated=True`)
+- **Read-only**: Database is read-only (`readonly=True`)
+
+Only persistent and replicated databases support the `fetch`, `store`, `delete`, `iter`, and `batch_op` operations.
+
+## Building from Source
+
+The extension is built using the Samba build system (waf):
+
+```bash
+# Configure
+./configure --enable-debug
+
+# Build
+make
+
+# The module will be in bin/default/ctdb/
+ls -l bin/default/ctdb/pyctdb*.so
+```
+
+## Development
+
+### Source Files
+
+- `pyclient.h` - Main header with type definitions and function declarations
+- `pyclient_module.c` - Module initialization
+- `pyclient_client.c` - Client class implementation
+- `pyclient_db.c` - Database class implementation
+- `pyclient_db_batch.c` - Batch operations support
+- `pyclient_db_iter.c` - Database iterator implementation
+- `pyclient_error.c` - Exception handling
+- `pyclient_tables.h` - Enumeration tables for node flags and capabilities
+
+### Adding New Features
+
+When adding new functionality:
+
+1. Update the appropriate source file
+2. Add function declarations to `pyclient.h`
+3. Update module state if adding new types
+4. Add proper error handling
+5. Release GIL for long-running operations
+6. Update this README with documentation
+
+## License
+
+This code is part of the Samba project and is licensed under the GNU General Public License version 3 or later.

--- a/ctdb/pyclient/pyclient.h
+++ b/ctdb/pyclient/pyclient.h
@@ -1,0 +1,236 @@
+/*
+   CTDB python client
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PYCLIENT_H
+#define PYCLIENT_H
+
+#include "replace.h"
+#include "system/network.h"
+#include "system/filesys.h"
+#include "system/time.h"
+#include "system/dir.h"
+
+#include <talloc.h>
+#include <tevent.h>
+#include <tdb.h>
+
+#include "lib/util/samba_util.h"
+
+#include <Python.h>
+#include "python/py3compat.h"
+#include "common/path.h"
+#include "protocol/protocol.h"
+#include "protocol/protocol_api.h"
+#include "protocol/protocol_util.h"
+#include "protocol/protocol_basic.h"
+#include "common/system_socket.h"
+#include "client/client.h"
+#include "client/client_private.h"
+#include "client/client_sync.h"
+
+
+#define PYMODULE_NAME	"pyctdb"
+
+/*
+ * Module state definition. This holds references to various enums that we use
+ * to construct python getattr responses for ctdb objects as well as module
+ * exception types for error handling.
+ */
+typedef struct {
+	/* See pyclient_tables.h */
+	PyObject *py_node_status_enum;
+	PyObject *py_db_flags_enum;
+	PyObject *py_ctdb_caps_enum;
+	/* See pyclient_error.c */
+	PyObject *py_ctdb_error;
+	/* See pyclient_db_batch.c */
+	PyTypeObject *py_batch_op_type;
+} pyctdb_mod_state_t;
+
+/*
+ * WARNING: this should only be consumed in module method to free module.
+ * It is present here *merely* to help keep in sync with what needs to be
+ * freed from the module state
+ */
+#define PYCLEAR_MOD_STATE(state) do { \
+       Py_CLEAR(state->py_node_status_enum); \
+       Py_CLEAR(state->py_db_flags_enum); \
+       Py_CLEAR(state->py_ctdb_caps_enum); \
+       Py_CLEAR(state->py_ctdb_error); \
+       Py_CLEAR(state->py_batch_op_type); \
+} while (0);
+
+/*
+ * From pyclient_module.c
+ * retrieve a pointer to the pyctdb module state structure. This takes an
+ * optional argument to provide a reference to the current module object
+ * (if available) as an optimization. If NULL then we'll look it up.
+ *
+ * NOTE: this function cannot fail / return NULL (will abort on failure)
+ *
+ * WARNING: this returns a borrowed reference to the state. Caller should
+ * not free / clear it.
+ */
+extern pyctdb_mod_state_t *pyctdb_get_state(PyObject *module_ref);
+
+typedef struct {
+	PyObject_HEAD;
+	TALLOC_CTX *mem_ctx;
+	pthread_mutex_t client_lock;
+	struct tevent_context *ev;
+	struct ctdb_client_context *client;
+	const char *ctdb_socket;
+	uint32_t pnn;
+	uint32_t target_pnn;
+	uint64_t srvid;
+	uint32_t timeout;
+	struct ctdb_node_map nodemap_cached;
+} py_ctdb_client_ctx;
+
+typedef struct {
+	PyObject_HEAD;
+	char db_name[MAXNAMLEN];
+	py_ctdb_client_ctx *client;
+	struct ctdb_db_context *db;
+	uint32_t db_id;
+	uint8_t db_flags;
+} py_ctdb_db_ctx;
+
+/*
+ * This macros specifically handle global locking when talloc leak reporting is
+ * enabled. This is because the NULL context with leak reporting enabled is
+ * actually a talloc chunk and so the talloc API as used here is not thread-safe.
+ *
+ * leak_reporting_enabled will only ever be changed while GIL is held and so we
+ * shouldn't have to worry about toctou here. This is mostly a debugging feature
+ * to generate a talloc leak report on script exit.
+ */
+extern unsigned leak_reporting_enabled;
+extern unsigned glock_enabled;
+extern uint32_t cluster_leader;
+extern pthread_mutex_t py_g_lock;
+
+#define TIMEOUT(client)    timeval_current_ofs(client->timeout, 0)
+
+#define PYCTDB_LEAK_LOCK() do { \
+	if (_Py_atomic_load_uint(&glock_enabled)) { \
+		pthread_mutex_lock(&py_g_lock); \
+	} \
+} while (0);
+
+#define PYCTDB_LEAK_UNLOCK() do { \
+	if (_Py_atomic_load_uint(&glock_enabled)) { \
+		pthread_mutex_unlock(&py_g_lock); \
+	} \
+} while (0);
+
+/*
+ * The following macros are to simplify code that performs ctdb client
+ * operations. Locks should be taken when python methods perform operations to
+ * help protect python users from having multiple threads performing operations
+ * concurrently on talloc-ed memory
+ */
+#define PYCTDB_LOCK(obj) do { \
+	PYCTDB_LEAK_LOCK(); \
+	pthread_mutex_lock(&obj->client_lock); \
+} while (0);
+
+#define PYCTDB_UNLOCK(obj) do { \
+	pthread_mutex_unlock(&obj->client_lock); \
+	PYCTDB_LEAK_UNLOCK(); \
+} while (0);
+
+/*
+ * Print a fatal error message and kill the process. No cleanup is performed.
+ * This should only be invoked for conditions that make it dangerous to
+ * continue using the module. For example apparent state corruption. This will
+ * call abort() and attempt to produce a corefile.
+ */
+#define PYCTDB_ASSERT_IMPL(test, message, location) do {\
+	if (!test) { \
+		Py_FatalError(message " [" location "]"); \
+	} \
+} while (0);
+
+#define PYCTDB_ASSERT(test, message)\
+	PYCTDB_ASSERT_IMPL(test, message, __location__)
+
+extern PyTypeObject PyCtdbClient;
+extern PyTypeObject PyCtdbDB;
+extern PyTypeObject PyCtdbDBIter;
+
+extern PyObject *py_get_or_create_db(py_ctdb_client_ctx *client,
+				     const char *db_name,
+				     uint8_t db_flags,
+				     bool create_ok);
+
+extern PyObject *py_ctdb_get_nodemap(py_ctdb_client_ctx *ctx, bool refresh);
+
+/* python exception */
+extern bool setup_ctdb_exception(PyObject *module_ref);
+extern void _set_ctdb_exc(int code, const char *additional_info,
+			  const char *location);
+#define pyctdb_err(code, info) \
+	_set_ctdb_exc(code, info, __location__)
+
+/* error structures for when GIL not held */
+typedef struct {
+	int code;
+        char message[1024];
+} pyctdb_error_t;
+
+/* Database iterator */
+extern PyObject *py_ctdb_db_iter_new(py_ctdb_db_ctx *db_ctx);
+
+/* Internal fetch function used by iterator */
+extern int py_ctdb_fetchrecord(py_ctdb_db_ctx *pydb, TDB_DATA key,
+			       TDB_DATA *data, pyctdb_error_t *pyerr);
+
+/* Internal error setting function */
+extern void _pyctdb_set_error(pyctdb_error_t *error, int error_code,
+			      const char *fmt, const char *location, ...);
+#define pyctdb_set_error(error, code, fmt, ...) \
+	_pyctdb_set_error(error, code, fmt, __location__, ##__VA_ARGS__)
+
+/* Batch operations - see pyclient_db_batch.c */
+enum batch_action {
+	BATCH_ACTION_GET = 0,
+	BATCH_ACTION_SET,
+	BATCH_ACTION_DEL,
+};
+
+struct batch_operation {
+	enum batch_action action;
+	TDB_DATA key;
+	TDB_DATA value;
+};
+
+struct batch_state {
+	struct batch_operation *ops;
+	size_t num_ops;
+	size_t capacity;
+	PyObject **results;
+	pyctdb_error_t error;
+};
+
+extern bool setup_batch_op_type(PyObject *module_ref);
+extern int parse_batch_operations(PyObject *operations, struct batch_state *state);
+extern int execute_batch_operations(py_ctdb_db_ctx *pydb, struct batch_state *state);
+extern PyObject *build_batch_result_dict(struct batch_state *state);
+extern void free_batch_state(struct batch_state *state);
+
+#endif /* PYCLIENT_H */

--- a/ctdb/pyclient/pyclient_client.c
+++ b/ctdb/pyclient/pyclient_client.c
@@ -1,0 +1,600 @@
+/*
+   CTDB python client
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pyclient.h"
+#include "pyclient_tables.h"
+
+#define SRVID_PY_CTDB	(CTDB_SRVID_TOOL_RANGE | 0x0001000000000000LL)
+#define DEFAULT_TIMEOUT 10
+unsigned leak_reporting_enabled;
+unsigned glock_enabled;
+
+/* There's only ever one leader and so we'll store this as a global */
+uint32_t cluster_leader = CTDB_UNKNOWN_PNN;
+
+pthread_mutex_t py_g_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/*
+ * Get nodemap allocated under python memory allocator. Does not require GIL,
+ * but does require the client context lock being held
+ */
+static
+int get_nodemap_internal(TALLOC_CTX *mem_ctx,
+			 struct tevent_context *ev,
+			 struct ctdb_client_context *client,
+			 int target_node,
+			 struct timeval timeout,
+			 struct ctdb_node_and_flags **nodes_array,
+			 uint32_t *node_cnt)
+{
+	TALLOC_CTX *tmp_ctx = talloc_new(mem_ctx);
+	struct ctdb_node_map *nodemap = NULL;
+	struct ctdb_node_and_flags *nodes = NULL;
+	int err;
+
+	if (tmp_ctx == NULL) {
+		return -ENOMEM;
+	}
+
+	err = ctdb_ctrl_get_nodemap(tmp_ctx, ev, client, target_node,
+				    timeout, &nodemap);
+	if (err) {
+		TALLOC_FREE(tmp_ctx);
+		return err;
+	}
+
+	nodes = PyMem_RawCalloc(nodemap->num, sizeof(struct ctdb_node_and_flags));
+	if (nodes == NULL) {
+		TALLOC_FREE(tmp_ctx);
+		return -ENOMEM;
+	}
+
+	memcpy(nodes, nodemap->node,
+	       nodemap->num * sizeof( struct ctdb_node_and_flags));
+
+	*node_cnt = nodemap->num;
+	*nodes_array = nodes;
+	TALLOC_FREE(tmp_ctx);
+	return 0;
+}
+
+static
+PyObject *py_node_flags_parse(uint32_t flags)
+{
+	PyObject *out = NULL;
+	int i;
+
+	out = PyList_New(0);
+	if (out == NULL) {
+		return NULL;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(node_flags_tbl); i++) {
+		PyObject *pyflag;
+		int rv;
+		if ((flags & node_flags_tbl[i].val) == 0)
+			continue;
+
+		pyflag = PyUnicode_FromString(
+			node_flags_tbl[i].name
+		);
+		if (pyflag == NULL) {
+			Py_DECREF(out);
+			return NULL;
+		}
+		rv = PyList_Append(out, pyflag);
+		Py_DECREF(pyflag);
+		if (rv == -1) {
+			Py_DECREF(out);
+			return NULL;
+		}
+	}
+
+	return out;
+}
+
+static
+PyObject *py_node(const struct ctdb_node_and_flags *node, int this_node)
+{
+	PyObject *out = NULL;
+	PyObject *pyflags = NULL;
+	char cip[128] = {0};
+	int err;
+
+	err = ctdb_sock_addr_to_buf(cip, sizeof(cip),
+				    discard_const_p(ctdb_sock_addr, &node->addr),
+				    true);
+	if (err) {
+		pyctdb_err(err, "Failed to parse ctdb socket address");
+		return NULL;
+	}
+
+	pyflags = py_node_flags_parse(node->flags);
+	if (pyflags == NULL)
+		goto cleanup;
+
+	out = Py_BuildValue(
+		"{s:I,s:s,s:O,s:O}",
+		"pnn", node->pnn,
+		"address", cip,
+		"flags", pyflags,
+		"this_node", node->pnn == this_node ? Py_True : Py_False
+	);
+
+cleanup:
+	Py_CLEAR(pyflags);
+	return out;
+}
+
+static
+PyObject *py_nodemap(const struct ctdb_node_map *nodemap, int this_node)
+{
+	PyObject *nodes_list = NULL;
+	uint32_t i;
+
+	if (nodemap->num == 0 || nodemap->node == NULL) {
+		pyctdb_err(EINVAL, "nodemap not properly initialized");
+		return NULL;
+	}
+
+	nodes_list = PyList_New(0);
+	if (nodes_list == NULL) {
+		return NULL;
+	}
+
+	for (i = 0; i < nodemap->num; i++) {
+		PyObject *pynode = NULL;
+		struct ctdb_node_and_flags *node = &nodemap->node[i];
+		int rv;
+
+		if (node->flags & NODE_FLAGS_DELETED)
+			continue;
+
+		pynode = py_node(node, this_node);
+		if (pynode == NULL) {
+			Py_DECREF(nodes_list);
+			return NULL;
+		}
+
+		rv = PyList_Append(nodes_list, pynode);
+		Py_DECREF(pynode);
+		if (rv == -1) {
+			Py_DECREF(nodes_list);
+			return NULL;
+		}
+
+	}
+
+	return nodes_list;
+}
+
+static void leader_handler(uint64_t srvid, TDB_DATA data, void *private_data)
+{
+	uint32_t leader_pnn;
+	size_t np;
+	int ret;
+
+	ret = ctdb_uint32_pull(data.dptr, data.dsize, &leader_pnn, &np);
+	if (ret != 0) {
+		/* Ignore packet */
+		return;
+	}
+
+	_Py_atomic_store_uint32(&cluster_leader, leader_pnn);
+}
+
+/* CTDB client object functions */
+static int py_ctdb_client_init(py_ctdb_client_ctx *self,
+			       PyObject *args_unused,
+			       PyObject *kwargs_unused)
+{
+	int err = 0;
+	uint64_t srvid_offset;
+	const char *errmsg = NULL;
+
+	/*
+	 * Create a new talloc context. Since there are no other talloc chunks
+	 * using this we are safe to do without GIL and only taking lock if
+	 * required for talloc leak check.
+	 */
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LEAK_LOCK();
+	self->mem_ctx = talloc_new(NULL);
+	if (self->mem_ctx == NULL) {
+		errmsg = "talloc_new() failed";
+		errno = ENOMEM;
+	} else {
+		self->ev = tevent_context_init(self->mem_ctx);
+		if (self->ev == NULL) {
+			errmsg = "tevent_context_init() failed";
+			TALLOC_FREE(self->mem_ctx);
+		} else {
+			self->ctdb_socket = path_socket(self->mem_ctx, "ctdbd");
+			if (self->ctdb_socket == NULL) {
+				errmsg = "path_socket() for ctdb socket failed";
+				TALLOC_FREE(self->mem_ctx);
+			}
+		}
+	}
+
+	/* We should have all required info set up to create the ctdb client connection */
+	if (errmsg == NULL) {
+		err = ctdb_client_init(
+			self->mem_ctx, self->ev, self->ctdb_socket, &self->client
+		);
+		if (err) {
+			errmsg = "ctdb_client_init() failed";
+			errno = err;
+		} else {
+			self->pnn = ctdb_client_pnn(self->client);
+			self->target_pnn = self->pnn;
+			srvid_offset = getpid() & 0xFFFF;
+			self->srvid = SRVID_PY_CTDB | (srvid_offset << 16);
+			self->timeout = DEFAULT_TIMEOUT;
+		}
+	}
+
+	if (err == 0) {
+		/* We want to update the client information if leader changes */
+		err = ctdb_client_set_message_handler(self->ev,
+						      self->client,
+						      CTDB_SRVID_LEADER,
+						      leader_handler,
+						      NULL);
+		if (err) {
+			errmsg = "ctdb_client_set_message_handler() failed";
+			errno = err;
+		} else {
+			pthread_mutex_init(&self->client_lock, NULL);
+		}
+	}
+
+	if (err) {
+		TALLOC_FREE(self->mem_ctx);
+	}
+
+	PYCTDB_LEAK_UNLOCK();
+	Py_END_ALLOW_THREADS
+
+	/*
+	 * At this point we've reacquired the GIL and so it's safe to generate python
+	 * errors
+	 */
+
+	if (err) {
+		pyctdb_err(errno, errmsg);
+		return -1;
+	}
+
+	return 0;
+}
+
+static
+void py_ctdb_client_dealloc(py_ctdb_client_ctx *self)
+{
+	/*
+	 * We'll drop GIL for TALLOC_FREE since the destructors involved may
+	 * be involved and long-running.
+	 */
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(self);
+
+	TALLOC_FREE(self->mem_ctx);
+
+	PYCTDB_UNLOCK(self);
+
+	PyMem_RawFree(self->nodemap_cached.node);
+	Py_END_ALLOW_THREADS
+
+	pthread_mutex_destroy(&self->client_lock);
+
+	Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static
+PyObject *py_ctdb_get_pnn(PyObject *self, void *closure)
+{
+	py_ctdb_client_ctx *ctx = (py_ctdb_client_ctx *)self;
+	return Py_BuildValue("I", ctx->pnn);
+}
+
+static
+PyObject *py_ctdb_get_leader(PyObject *self, void *closure)
+{
+	uint32_t leader = _Py_atomic_load_uint32(&cluster_leader);
+	return Py_BuildValue("I", leader);
+}
+
+static
+PyObject *py_ctdb_get_timeout(PyObject *self, void *closure)
+{
+	py_ctdb_client_ctx *ctx = (py_ctdb_client_ctx *)self;
+	return Py_BuildValue("I", ctx->timeout);
+}
+
+static
+int py_ctdb_set_timeout(py_ctdb_client_ctx *self,
+			PyObject *value, void *closure)
+{
+	py_ctdb_client_ctx *ctx = (py_ctdb_client_ctx *)self;
+	long val;
+
+	if (!PyLong_Check(value)) {
+		PyErr_SetString(PyExc_TypeError,
+				"Timeout must be an integer between 1 and 300");
+		return -1;
+	}
+
+	val = PyLong_AsLong(value);
+	if (val > 300 || val < 1) {
+		if (PyErr_Occurred()) {
+			return -1;
+		}
+
+		PyErr_SetString(PyExc_ValueError,
+				"Timeout must be between 1 and 300");
+		return -1;
+	}
+
+	ctx->timeout = val;
+	return 0;
+}
+
+/* CTDB client definitions */
+PyDoc_STRVAR(py_ctdb_pnn__doc__,
+"pnn -> int\n"
+"----------\n"
+"The physical node number (PNN) of this CTDB client.\n"
+);
+
+PyDoc_STRVAR(py_ctdb_leader__doc__,
+"leader -> int\n"
+"-------------\n"
+"The PNN of the current cluster leader node.\n"
+);
+
+PyDoc_STRVAR(py_ctdb_timeout__doc__,
+"timeout -> int\n"
+"--------------\n"
+"Timeout in seconds for CTDB operations (1-300).\n"
+);
+
+static PyGetSetDef ctdb_client_getsetters[] = {
+	{
+		.name = discard_const_p(char, "pnn"),
+		.get = (getter)py_ctdb_get_pnn,
+		.doc = py_ctdb_pnn__doc__,
+	},
+	{
+		.name = discard_const_p(char, "leader"),
+		.get = (getter)py_ctdb_get_leader,
+		.doc = py_ctdb_leader__doc__,
+	},
+	{
+		.name = discard_const_p(char, "timeout"),
+		.get = (getter)py_ctdb_get_timeout,
+		.set = (setter)py_ctdb_set_timeout,
+		.doc = py_ctdb_timeout__doc__,
+	},
+	{ .name = NULL }
+};
+
+PyObject *py_ctdb_get_nodemap(py_ctdb_client_ctx *ctx, bool refresh)
+{
+	int err;
+
+	if (ctx->nodemap_cached.node == NULL) {
+		/* We've never initialized a nodemap and so need a fresh one */
+		refresh = true;
+	}
+
+	if (refresh) {
+		Py_BEGIN_ALLOW_THREADS
+		PYCTDB_LOCK(ctx);
+		err = get_nodemap_internal(ctx->mem_ctx,
+					   ctx->ev,
+					   ctx->client,
+					   ctx->pnn,
+					   TIMEOUT(ctx),
+					   &ctx->nodemap_cached.node,
+					   &ctx->nodemap_cached.num);
+		PYCTDB_UNLOCK(ctx);
+		Py_END_ALLOW_THREADS
+		if (err) {
+			pyctdb_err(err, "Failed to refresh nodemap");
+			return NULL;
+		}
+	}
+
+	return py_nodemap(&ctx->nodemap_cached, ctx->pnn);
+}
+
+static
+PyObject *py_ctdb_nodemap(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_client_ctx *ctx = (py_ctdb_client_ctx *)self;
+	bool refresh = false;
+	static char *kwlist[] = {"refresh", NULL};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|b", kwlist, &refresh)) {
+		return NULL;
+	}
+
+	return py_ctdb_get_nodemap(ctx, refresh);
+}
+
+static
+PyObject *py_ctdb_status(PyObject *self, PyObject *args_unused)
+{
+	py_ctdb_client_ctx *ctx = (py_ctdb_client_ctx *)self;
+	PyObject *pynodemap = NULL;
+	PyObject *out = NULL;
+	enum ctdb_runstate runstate;
+	int err, recmode;
+	const char *errmsg;
+
+	pynodemap = py_ctdb_get_nodemap(ctx, true);
+	if (pynodemap == NULL)
+		return NULL;
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(ctx);
+	err = ctdb_ctrl_get_recmode(ctx->mem_ctx, ctx->ev, ctx->client,
+				    ctx->target_pnn, TIMEOUT(ctx), &recmode);
+	if (err == 0) {
+		err = ctdb_ctrl_get_runstate(ctx->mem_ctx, ctx->ev, ctx->client,
+					     ctx->target_pnn, TIMEOUT(ctx), &runstate);
+		if (err)
+			errmsg = "Failed to get runstate";
+	} else {
+		errmsg = "Failed to get recovery mode";
+	}
+	PYCTDB_UNLOCK(ctx);
+	Py_END_ALLOW_THREADS
+
+	if (err) {
+		pyctdb_err(err, errmsg);
+		Py_DECREF(pynodemap);
+		return NULL;
+	}
+
+	out = Py_BuildValue(
+		"{s:O,s:s,s:s,s:I}",
+		"nodemap", pynodemap,
+		"recovery_mode", recmode == CTDB_RECOVERY_NORMAL ? "NORMAL" : "RECOVERY",
+		"state", ctdb_runstate_to_string(runstate),
+		"leader_pnn", _Py_atomic_load_uint32(&cluster_leader)
+	);
+	Py_DECREF(pynodemap);
+	return out;
+}
+
+PyDoc_STRVAR(py_ctdb_status__doc__,
+"status() -> dict\n"
+"----------------\n"
+"Retrieve the current status of the CTDB cluster.\n"
+"\n"
+"Returns:\n"
+"    A dictionary containing:\n"
+"        nodemap: list of node information dictionaries\n"
+"        recovery_mode: 'NORMAL' or 'RECOVERY'\n"
+"        state: the cluster's run state\n"
+"        leader_pnn: PNN of the cluster leader\n"
+);
+
+PyDoc_STRVAR(py_ctdb_nodemap__doc__,
+"nodemap(refresh=False) -> list\n"
+"-------------------------------\n"
+"Retrieve the node map of the CTDB cluster.\n"
+"\n"
+"Args:\n"
+"    refresh: If True, fetch fresh nodemap from cluster.\n"
+"             If False, use cached nodemap (default).\n"
+"\n"
+"Returns:\n"
+"    A list of dictionaries, each containing:\n"
+"        pnn: physical node number\n"
+"        address: node's network address\n"
+"        flags: list of node flag strings\n"
+"        this_node: boolean indicating if this is the local node\n"
+);
+
+static
+PyObject *py_ctdb_get_db(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_client_ctx *ctx = (py_ctdb_client_ctx *)self;
+	const char *db_name = NULL;
+	uint8_t db_flags = 0;
+	int persistent = 1;
+	int readonly = 0;
+	int replicated = 0;
+	int create_ok = 0;
+	static char *kwlist[] = {
+		"db_name", "persistent", "readonly", "replicated",
+		"create_ok", NULL
+	};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|pppp", kwlist,
+					 &db_name, &persistent, &readonly,
+					 &replicated, &create_ok)) {
+		return NULL;
+	}
+
+	/* Build db_flags from boolean arguments */
+	if (persistent) {
+		db_flags |= CTDB_DB_FLAGS_PERSISTENT;
+	}
+	if (readonly) {
+		db_flags |= CTDB_DB_FLAGS_READONLY;
+	}
+	if (replicated) {
+		db_flags |= CTDB_DB_FLAGS_REPLICATED;
+	}
+
+	return py_get_or_create_db(ctx, db_name, db_flags, (bool)create_ok);
+}
+
+PyDoc_STRVAR(py_ctdb_get_db__doc__,
+"get_db(db_name, persistent=True, readonly=False, replicated=False,\n"
+"       create_ok=False) -> CtdbDB\n"
+"-----------------------------------------------------------------------\n"
+"Open or create a CTDB database.\n"
+"\n"
+"Args:\n"
+"    db_name: Name of the database to open\n"
+"    persistent: Database is persistent (default: True)\n"
+"    readonly: Database is read-only (default: False)\n"
+"    replicated: Database is replicated (default: False)\n"
+"    create_ok: If True, create database if it doesn't exist (default: False)\n"
+"\n"
+"Returns:\n"
+"    A CtdbDB object representing the opened database\n"
+);
+
+static PyMethodDef ctdb_client_methods[] = {
+	{
+		.ml_name = "status",
+		.ml_meth = py_ctdb_status,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_ctdb_status__doc__,
+	},
+	{
+		.ml_name = "nodemap",
+		.ml_meth = (PyCFunction)py_ctdb_nodemap,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_nodemap__doc__,
+	},
+	{
+		.ml_name = "get_db",
+		.ml_meth = (PyCFunction)py_ctdb_get_db,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_get_db__doc__,
+	},
+	{ NULL, NULL, 0, NULL }
+};
+
+PyTypeObject PyCtdbClient = {
+	.tp_name = PYMODULE_NAME ".Client",
+	.tp_basicsize = sizeof(py_ctdb_client_ctx),
+	.tp_methods = ctdb_client_methods,
+	.tp_getset = ctdb_client_getsetters,
+	.tp_doc = "A CTDB client",
+	.tp_new = PyType_GenericNew,
+	.tp_init = (initproc)py_ctdb_client_init,
+	.tp_dealloc = (destructor)py_ctdb_client_dealloc,
+	.tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,
+};

--- a/ctdb/pyclient/pyclient_db.c
+++ b/ctdb/pyclient/pyclient_db.c
@@ -1,0 +1,1201 @@
+/*
+   CTDB python client
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pyclient.h"
+#include "pyclient_tables.h"
+#include "lib/util/dlinklist.h"
+
+static int py_ctdb_db_init(py_ctdb_db_ctx *self,
+			   PyObject *args,
+			   PyObject *kwargs)
+{
+	return 0;
+}
+
+static
+void py_ctdb_db_dealloc(py_ctdb_db_ctx *self)
+{
+	if (self->client == NULL) {
+		Py_TYPE(self)->tp_free((PyObject *)self);
+		return;
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(self->client);
+
+	/*
+	 * Do not free self->db - it is owned by the client context
+	 * and will be freed when the client is freed. The db context
+	 * may also be shared by multiple Python DB objects (attach
+	 * reuses existing db handles), so freeing it here would cause
+	 * use-after-free bugs.
+	 */
+	self->db = NULL;
+
+	PYCTDB_UNLOCK(self->client);
+	Py_END_ALLOW_THREADS
+	Py_CLEAR(self->client);
+	Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static
+int get_generation(py_ctdb_client_ctx *pyclient, uint32_t *generation)
+{
+	uint32_t leader = _Py_atomic_load_uint32(&cluster_leader);
+	int recmode;
+	struct ctdb_vnn_map *vnnmap;
+	TALLOC_CTX *tmp_ctx = NULL;
+	int err;
+	const char *errmsg;
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(pyclient);
+	tmp_ctx = talloc_new(pyclient->mem_ctx);
+	if (tmp_ctx == NULL) {
+		err = ENOMEM;
+		errmsg = "Failed to allocate new memory context";
+	} else {
+		err = ctdb_ctrl_get_recmode(tmp_ctx,
+					    pyclient->ev,
+					    pyclient->client,
+					    leader,
+					    TIMEOUT(pyclient),
+					    &recmode);
+		if (err) {
+			errmsg = "Failed to get recovery mode";
+		}
+	}
+
+	if (!err && (recmode == CTDB_RECOVERY_ACTIVE)) {
+		err = EBUSY;
+		errmsg = "Ctdb cluster is currently in recovery mode";
+	} else if (!err) {
+		err = ctdb_ctrl_getvnnmap(tmp_ctx,
+					  pyclient->ev,
+					  pyclient->client,
+					  leader,
+					  TIMEOUT(pyclient),
+					  &vnnmap);
+		if (err) {
+			errmsg = "Failed to get generation from node";
+		} else {
+			*generation = vnnmap->generation;
+		}
+	}
+	TALLOC_FREE(tmp_ctx);
+	PYCTDB_UNLOCK(pyclient);
+	Py_END_ALLOW_THREADS
+
+	if (err) {
+		// Set python exception
+		pyctdb_err(err, errmsg);
+	}
+
+	return err;
+}
+
+static
+int py_ctdb_wipedb(py_ctdb_db_ctx *dbctx)
+{
+	uint32_t leader = _Py_atomic_load_uint32(&cluster_leader);
+	int count, err;
+	bool frozen = false;
+	uint32_t *pnn_list;
+	uint32_t generation;
+	struct ctdb_req_control request;
+	struct ctdb_transdb wipedb;
+	const char *errmsg = NULL;
+	TALLOC_CTX *tmp_ctx = NULL;
+
+	PYCTDB_ASSERT((dbctx != NULL), "uninitialized db context");
+
+	if (leader != dbctx->client->pnn) {
+		PyErr_SetString(PyExc_ValueError,
+				"DB wipe operations must be initiated by "
+				"the cluster leader.");
+		return EINVAL;
+	}
+
+	if (dbctx->client->nodemap_cached.node == NULL) {
+		/*
+		 * This function requires an initialized nodemap
+		 * we'll use the python function because it's readily
+		 * available and having a cached nodemap is OK.
+		 */
+		PyObject *tmp = py_ctdb_get_nodemap(dbctx->client, true);
+		if (tmp == NULL) {
+			return EINVAL;
+		}
+
+		Py_DECREF(tmp);
+	}
+
+	err = get_generation(dbctx->client, &generation);
+	if (err)
+		return err;
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(dbctx->client);
+	tmp_ctx = talloc_new(dbctx->client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		err = ENOMEM;
+		errmsg = "Failed to allocate new memory context";
+	} else {
+		count = list_of_active_nodes(&dbctx->client->nodemap_cached,
+					     CTDB_UNKNOWN_PNN,
+					     tmp_ctx,
+					     &pnn_list);
+		if (count < 0) {
+			err = ENOMEM;
+			errmsg = "Failed to list active nodes";
+		}
+	}
+
+	if (!err) {
+		ctdb_req_control_db_freeze(&request, dbctx->db_id);
+		err = ctdb_client_control_multi(tmp_ctx, dbctx->client->ev,
+						dbctx->client->client,
+						pnn_list, count,
+						TIMEOUT(dbctx->client),
+						&request, NULL, NULL);
+		if (err) {
+			errmsg = "Failed to issue freeze";
+		} else {
+			frozen = true;
+		}
+	}
+
+	if (frozen) {
+		wipedb.db_id = dbctx->db_id;
+		wipedb.tid = generation;
+		ctdb_req_control_db_transaction_start(&request, &wipedb);
+		err = ctdb_client_control_multi(tmp_ctx, dbctx->client->ev,
+						dbctx->client->client,
+						pnn_list, count,
+						TIMEOUT(dbctx->client),
+						&request, NULL, NULL);
+		if (err) {
+			errmsg = "Failed to wipe database";
+		} else {
+			ctdb_req_control_db_set_healthy(&request, dbctx->db_id);
+			err = ctdb_client_control_multi(tmp_ctx, dbctx->client->ev,
+							 dbctx->client->client,
+							 pnn_list, count,
+							 TIMEOUT(dbctx->client),
+							 &request, NULL, NULL);
+			if (err) {
+				errmsg = "Failed to set healthy";
+			}
+		}
+
+		/* commit the transaction */
+		if (!err) {
+			ctdb_req_control_db_transaction_commit(&request, &wipedb);
+			err = ctdb_client_control_multi(tmp_ctx, dbctx->client->ev,
+							 dbctx->client->client,
+							 pnn_list, count,
+							 TIMEOUT(dbctx->client),
+							 &request, NULL, NULL);
+			if (err) {
+				errmsg = "Failed to commit transaction";
+			}
+		}
+
+		/* unfreeze */
+		if (!err) {
+			ctdb_req_control_db_thaw(&request, dbctx->db_id);
+			err = ctdb_client_control_multi(tmp_ctx, dbctx->client->ev,
+							 dbctx->client->client,
+							 pnn_list, count,
+							 TIMEOUT(dbctx->client),
+							 &request, NULL, NULL);
+			if (err) {
+				errmsg = "Failed to unfreeze DB";
+			}
+		}
+
+	}
+
+	if (err) {
+		ctdb_ctrl_set_recmode(tmp_ctx, dbctx->client->ev,
+				      dbctx->client->client,
+				      dbctx->client->pnn,
+				      TIMEOUT(dbctx->client),
+				      CTDB_RECOVERY_ACTIVE);
+	}
+
+	TALLOC_FREE(tmp_ctx);
+	PYCTDB_UNLOCK(dbctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err)
+		pyctdb_err(err, errmsg);
+
+	return err;
+}
+
+typedef struct ctdb_rec_del_entry {
+	TDB_DATA key;
+	struct ctdb_rec_del_entry *next, *prev;
+} del_entry_t;
+
+struct ctdb_tdb_sync_state {
+	del_entry_t *del_list;
+	TDB_CONTEXT *tctx;
+	TALLOC_CTX *mem_ctx;
+};
+
+static
+int gen_del_list(TDB_DATA key, TDB_DATA data, struct ctdb_tdb_sync_state *state)
+{
+	TDB_DATA val;
+	del_entry_t *d = NULL;
+
+	/*
+	 * Never delete the __db_sequence_number__ entry during sync.
+	 * This entry is managed by CTDB for persistent databases.
+	 */
+	if (key.dsize == (strlen(CTDB_DB_SEQNUM_KEY) + 1) &&
+	    memcmp(key.dptr, CTDB_DB_SEQNUM_KEY, key.dsize) == 0) {
+		return 0;
+	}
+
+	val = tdb_fetch(state->tctx, key);
+	if ((val.dptr == NULL) || (val.dsize != data.dsize)) {
+		goto copy_out;
+	} else if (memcmp(val.dptr, data.dptr, data.dsize) != 0) {
+		goto copy_out;
+	}
+
+	free(val.dptr);
+	return 0;
+copy_out:
+	// copy the key into our destroy list
+	d = talloc_zero(state->mem_ctx, del_entry_t);
+	if (d == NULL) {
+		free(val.dptr);
+		return ENOMEM;
+	}
+
+	d->key.dptr = talloc_memdup(state->mem_ctx,
+				    key.dptr,
+				    key.dsize);
+	if (d->key.dptr == NULL) {
+		free(val.dptr);
+		return ENOMEM;
+	}
+
+	d->key.dsize = key.dsize;
+	DLIST_ADD(state->del_list, d);
+	free(val.dptr);
+	return 0;
+}
+
+static
+int traverse_gen_del_list_cb(uint32_t reqid, struct ctdb_ltdb_header *header,
+			     TDB_DATA key, TDB_DATA data, void *private_data)
+{
+	struct ctdb_tdb_sync_state *state = NULL;
+	state = (struct ctdb_tdb_sync_state *)private_data;
+
+	return gen_del_list(key, data, state);
+}
+
+static
+int traverse_ctdb_local_for_del_list(struct ctdb_db_context *db,
+				     TALLOC_CTX *mem_ctx,
+				     TDB_CONTEXT *tctx,
+				     del_entry_t *del_list)
+{
+	int err;
+	struct ctdb_tdb_sync_state state = (struct ctdb_tdb_sync_state) {
+		.del_list = del_list,
+		.tctx = tctx,
+		.mem_ctx = mem_ctx
+	};
+
+	return ctdb_db_traverse_local(db, true, false,
+				      traverse_gen_del_list_cb, &state);
+}
+
+struct store_tdb_in_ctdb_state {
+	bool error_occurred;
+	pyctdb_error_t *error;
+	struct ctdb_transaction_handle *h;
+};
+
+static
+int store_tdb_record(TDB_CONTEXT *tctx, TDB_DATA key, TDB_DATA val,
+		     void *private_data)
+{
+	struct store_tdb_in_ctdb_state *state;
+	state = (struct store_tdb_in_ctdb_state *)private_data;
+	int err;
+
+	err = ctdb_transaction_store_record(state->h, key, val);
+	if (err) {
+		state->error_occurred = true;
+		pyctdb_set_error(state->error, err, "Failed to store tdb record.");
+	}
+
+	return err;
+}
+
+static
+int store_tdb_in_ctdb(struct ctdb_transaction_handle *h, TDB_CONTEXT *tctx, pyctdb_error_t *error)
+{
+	struct store_tdb_in_ctdb_state state = {.error = error, .h = h};
+	int rv;
+
+	rv = tdb_traverse(tctx, store_tdb_record, &state);
+	if (rv < 0) {
+		/* tdb error occurred */
+		pyctdb_set_error(error, errno, "TDB traversal failed");
+		return -1;
+	} else if (state.error_occurred) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static
+int sync_ctdb_and_tdb(py_ctdb_db_ctx *pydb, TDB_CONTEXT *tctx,
+		      pyctdb_error_t *error)
+{
+	int err;
+	TALLOC_CTX *tmp_ctx = NULL;
+	del_entry_t del_list = {0};
+	del_entry_t *de, *next;
+	struct ctdb_transaction_handle *h;
+
+	tmp_ctx = talloc_new(pydb->client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		pyctdb_set_error(error, ENOMEM, "Failed to create talloc context");
+		return ENOMEM;
+	}
+
+	err = traverse_ctdb_local_for_del_list(pydb->db, tmp_ctx, tctx, &del_list);
+	if (err) {
+		pyctdb_set_error(error, err, "Failed to traverse and create delete list");
+		TALLOC_FREE(tmp_ctx);
+		return err;
+	}
+
+	/* perform changes under transaction lock */
+	err = ctdb_transaction_start(tmp_ctx, pydb->client->ev,
+				     pydb->client->client, TIMEOUT(pydb->client),
+				     pydb->db, false, &h);
+	if (err) {
+		pyctdb_set_error(error, err, "Failed to start transaction.");
+		TALLOC_FREE(tmp_ctx);
+		return err;
+	}
+
+	/* first delete any records in the ctdb db that don't need to be there */
+	for (de = &del_list; de; de = next) {
+		next = de->next;
+		if (de->key.dptr == NULL)
+			continue;
+
+		err = ctdb_transaction_delete_record(h, de->key);
+		if (err) {
+			pyctdb_set_error(error, err, "Failed to delete record");
+			goto cancel_transaction;
+		}
+	}
+
+	/* now write all entries from the tdb file into transaction */
+	err = store_tdb_in_ctdb(h, tctx, error);
+	if (err) {
+		/* We already filled error buffer in store_tdb_in_ctdb() */
+		goto cancel_transaction;
+	}
+
+	/* now commit our transaction to ctdb db */
+	err = ctdb_transaction_commit(h);
+	if (err) {
+		pyctdb_set_error(error, err, "Failed to commit transaction");
+		goto cancel_transaction;
+	}
+
+	TALLOC_FREE(tmp_ctx);
+	return 0;
+
+cancel_transaction:
+	ctdb_transaction_cancel(h);
+	TALLOC_FREE(tmp_ctx);
+	return err;
+}
+
+static
+int py_ctdb_db_synchronize(py_ctdb_db_ctx *pydb, const char *tdb_path, int tdb_flags,
+			   int open_flags, mode_t mode)
+{
+	int err;
+	pyctdb_error_t pyerr;
+	TDB_CONTEXT *tctx;
+	uint32_t leader = _Py_atomic_load_uint32(&cluster_leader);
+
+	PYCTDB_ASSERT((pydb->client != NULL), "uninitialized db context");
+
+	if (pydb->client->pnn != leader) {
+		PyErr_SetString(PyExc_ValueError,
+				"This operation may only be performed on the "
+				"cluster leader.");
+		return EINVAL;
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(pydb->client);
+	tctx = tdb_open(tdb_path, 0, tdb_flags, open_flags, mode);
+	if (tctx == NULL) {
+		err = errno;
+		pyctdb_set_error(&pyerr, err, "%s: failed to open tdb file", tdb_path);
+	} else {
+		err = sync_ctdb_and_tdb(pydb, tctx, &pyerr);
+		tdb_close(tctx);
+	}
+	PYCTDB_UNLOCK(pydb->client);
+	Py_END_ALLOW_THREADS
+
+	if (err) {
+		pyctdb_err(err, pyerr.message);
+	}
+
+	return err;
+}
+
+int py_ctdb_fetchrecord(py_ctdb_db_ctx *pydb, TDB_DATA key,
+			TDB_DATA *data, pyctdb_error_t *pyerr)
+{
+	struct ctdb_transaction_handle *h = NULL;
+	TALLOC_CTX *tmp_ctx;
+	TDB_DATA result = { .dptr = NULL, .dsize = 0 };
+	int err = 0;
+
+	PYCTDB_ASSERT((pydb->client != NULL), "uninitialized db context");
+
+	tmp_ctx = talloc_new(pydb->client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		pyctdb_set_error(pyerr, ENOMEM,
+				 "Failed to allocate memory context");
+		return ENOMEM;
+	}
+
+	err = ctdb_transaction_start(tmp_ctx, pydb->client->ev,
+				     pydb->client->client,
+				     TIMEOUT(pydb->client),
+				     pydb->db, true, &h);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to start transaction");
+		goto done;
+	}
+
+	err = ctdb_transaction_fetch_record(h, key, tmp_ctx, &result);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to fetch record");
+		ctdb_transaction_cancel(h);
+		goto done;
+	}
+
+	/* Check if record exists - NULL dptr indicates non-existent key */
+	if (result.dptr == NULL) {
+		pyctdb_set_error(pyerr, ENOENT, "Record not found");
+		err = ENOENT;
+		ctdb_transaction_cancel(h);
+		goto done;
+	}
+
+	/* Copy data to PyMem allocated memory so it survives tmp_ctx free */
+	if (result.dsize > 0) {
+		data->dptr = PyMem_RawCalloc(1, result.dsize);
+		if (data->dptr == NULL) {
+			pyctdb_set_error(pyerr, ENOMEM,
+					 "Failed to allocate memory for data");
+			err = ENOMEM;
+			ctdb_transaction_cancel(h);
+			goto done;
+		}
+		memcpy(data->dptr, result.dptr, result.dsize);
+		data->dsize = result.dsize;
+	}
+
+	ctdb_transaction_cancel(h);
+
+done:
+	TALLOC_FREE(tmp_ctx);
+	return err;
+}
+
+PyDoc_STRVAR(py_ctdb_db_fetch__doc__,
+"fetch(key) -> bytes\n"
+"--------------------\n"
+"Fetch a record from the CTDB database.\n"
+"\n"
+"Args:\n"
+"    key: Record key as bytes\n"
+"\n"
+"Returns:\n"
+"    bytes: The record value\n"
+"\n"
+"Raises:\n"
+"    FileNotFoundError: If the record does not exist\n"
+"    CtdbError: If the operation fails\n"
+);
+static PyObject *py_ctdb_db_fetch(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+	TDB_DATA key, data = { .dptr = NULL, .dsize = 0 };
+	PyObject *result = NULL;
+	int err;
+	pyctdb_error_t pyerr;
+	static char *kwlist[] = {"key", NULL};
+
+	PYCTDB_ASSERT((dbctx->client != NULL), "uninitialized db context");
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "y#", kwlist,
+					 &key.dptr, &key.dsize)) {
+		return NULL;
+	}
+
+	if (!(dbctx->db_flags &
+	      (CTDB_DB_FLAGS_PERSISTENT | CTDB_DB_FLAGS_REPLICATED))) {
+		PyErr_Format(PyExc_ValueError,
+			     "Database '%s' is not persistent or replicated",
+			     dbctx->db_name);
+		return NULL;
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(dbctx->client);
+	err = py_ctdb_fetchrecord(dbctx, key, &data, &pyerr);
+	PYCTDB_UNLOCK(dbctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err == 0) {
+		result = PyBytes_FromStringAndSize((const char *)data.dptr,
+						   data.dsize);
+		PyMem_RawFree(data.dptr);
+	} else if (err == ENOENT) {
+		PyErr_SetString(PyExc_FileNotFoundError,
+				"Record not found");
+	} else {
+		pyctdb_err(err, pyerr.message);
+	}
+
+	return result;
+}
+
+static int py_ctdb_storerecord(py_ctdb_db_ctx *pydb, TDB_DATA key,
+			       TDB_DATA value, pyctdb_error_t *pyerr)
+{
+	struct ctdb_transaction_handle *h = NULL;
+	TALLOC_CTX *tmp_ctx;
+	int err = 0;
+
+	PYCTDB_ASSERT((pydb->client != NULL), "uninitialized db context");
+
+	tmp_ctx = talloc_new(pydb->client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		pyctdb_set_error(pyerr, ENOMEM,
+				 "Failed to allocate memory context");
+		return ENOMEM;
+	}
+
+	err = ctdb_transaction_start(tmp_ctx, pydb->client->ev,
+				     pydb->client->client,
+				     TIMEOUT(pydb->client),
+				     pydb->db, false, &h);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to start transaction");
+		goto done;
+	}
+
+	err = ctdb_transaction_store_record(h, key, value);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to store record");
+		ctdb_transaction_cancel(h);
+		goto done;
+	}
+
+	err = ctdb_transaction_commit(h);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to commit transaction");
+		ctdb_transaction_cancel(h);
+		goto done;
+	}
+
+done:
+	TALLOC_FREE(tmp_ctx);
+	return err;
+}
+
+PyDoc_STRVAR(py_ctdb_db_store__doc__,
+"store(key, value) -> None\n"
+"-------------------------\n"
+"Store a record in the CTDB database.\n"
+"\n"
+"Args:\n"
+"    key: Record key as bytes\n"
+"    value: Record value as bytes\n"
+"\n"
+"Returns:\n"
+"    None\n"
+"\n"
+"Raises:\n"
+"    CtdbError: If the operation fails\n"
+);
+static PyObject *py_ctdb_db_store(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+	TDB_DATA key, value;
+	int err;
+	pyctdb_error_t pyerr;
+	static char *kwlist[] = {"key", "value", NULL};
+
+	PYCTDB_ASSERT((dbctx->client != NULL), "uninitialized db context");
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "y#y#", kwlist,
+					 &key.dptr, &key.dsize,
+					 &value.dptr, &value.dsize)) {
+		return NULL;
+	}
+
+	if (!(dbctx->db_flags &
+	      (CTDB_DB_FLAGS_PERSISTENT | CTDB_DB_FLAGS_REPLICATED))) {
+		PyErr_Format(PyExc_ValueError,
+			     "Database '%s' is not persistent or replicated",
+			     dbctx->db_name);
+		return NULL;
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(dbctx->client);
+	err = py_ctdb_storerecord(dbctx, key, value, &pyerr);
+	PYCTDB_UNLOCK(dbctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err != 0) {
+		pyctdb_err(err, pyerr.message);
+		return NULL;
+	}
+
+	Py_RETURN_NONE;
+}
+
+static int py_ctdb_deleterecord(py_ctdb_db_ctx *pydb, TDB_DATA key,
+				pyctdb_error_t *pyerr)
+{
+	struct ctdb_transaction_handle *h = NULL;
+	TALLOC_CTX *tmp_ctx;
+	int err = 0;
+
+	PYCTDB_ASSERT((pydb->client != NULL), "uninitialized db context");
+
+	tmp_ctx = talloc_new(pydb->client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		pyctdb_set_error(pyerr, ENOMEM,
+				 "Failed to allocate memory context");
+		return ENOMEM;
+	}
+
+	err = ctdb_transaction_start(tmp_ctx, pydb->client->ev,
+				     pydb->client->client,
+				     TIMEOUT(pydb->client),
+				     pydb->db, false, &h);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to start transaction");
+		goto done;
+	}
+
+	err = ctdb_transaction_delete_record(h, key);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to delete record");
+		ctdb_transaction_cancel(h);
+		goto done;
+	}
+
+	err = ctdb_transaction_commit(h);
+	if (err != 0) {
+		pyctdb_set_error(pyerr, err, "Failed to commit transaction");
+		ctdb_transaction_cancel(h);
+		goto done;
+	}
+
+done:
+	TALLOC_FREE(tmp_ctx);
+	return err;
+}
+
+PyDoc_STRVAR(py_ctdb_db_delete__doc__,
+"delete(key) -> None\n"
+"-------------------\n"
+"Delete a record from the CTDB database.\n"
+"\n"
+"Args:\n"
+"    key: Record key as bytes\n"
+"\n"
+"Returns:\n"
+"    None\n"
+"\n"
+"Raises:\n"
+"    CtdbError: If the operation fails\n"
+);
+static PyObject *py_ctdb_db_delete(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+	TDB_DATA key;
+	int err;
+	pyctdb_error_t pyerr;
+	static char *kwlist[] = {"key", NULL};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "y#", kwlist,
+					 &key.dptr, &key.dsize)) {
+		return NULL;
+	}
+
+	if (!(dbctx->db_flags &
+	      (CTDB_DB_FLAGS_PERSISTENT | CTDB_DB_FLAGS_REPLICATED))) {
+		PyErr_Format(PyExc_ValueError,
+			     "Database '%s' is not persistent or replicated",
+			     dbctx->db_name);
+		return NULL;
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(dbctx->client);
+	err = py_ctdb_deleterecord(dbctx, key, &pyerr);
+	PYCTDB_UNLOCK(dbctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err != 0) {
+		pyctdb_err(err, pyerr.message);
+		return NULL;
+	}
+
+	Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(py_ctdb_db_wipe_db__doc__,
+"wipe_db() -> None\n"
+"------------------\n"
+"Wipe the CTDB database, removing all records. This operation must be\n"
+"initiated by the cluster leader and will freeze the database, wipe its\n"
+"contents across all nodes, and then unfreeze it.\n"
+"\n"
+"Raises:\n"
+"    CtdbError: If the operation fails or if not called on cluster leader.\n"
+);
+static PyObject *py_ctdb_db_wipe_db(PyObject *self, PyObject *unused)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+	int err;
+
+	err = py_ctdb_wipedb(dbctx);
+	if (err) {
+		return NULL;
+	}
+
+	Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(py_ctdb_db_sync_with_tdb_file__doc__,
+"sync_with_tdb_file(tdb_path, tdb_flags=0, open_flags=0, mode=0644) -> None\n"
+"--------------------------------------------------------------------------\n"
+"Synchronize the CTDB database with a local TDB file. This operation reads\n"
+"the specified TDB file and ensures the CTDB database matches its contents.\n"
+"Records present in CTDB but not in the TDB file will be deleted. Records\n"
+"in the TDB file will be written to CTDB. This operation must be initiated\n"
+"by the cluster leader.\n"
+"\n"
+"Args:\n"
+"    tdb_path: Path to the TDB file to synchronize with\n"
+"    tdb_flags: TDB flags for opening the file (default: 0)\n"
+"    open_flags: File open flags (default: 0)\n"
+"    mode: File mode permissions (default: 0644)\n"
+"\n"
+"Raises:\n"
+"    CtdbError: If the operation fails, file cannot be opened, or if not\n"
+"               called on cluster leader.\n"
+);
+static PyObject *py_ctdb_db_sync_with_tdb_file(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+	const char *tdb_path = NULL;
+	int tdb_flags = 0;
+	int open_flags = 0;
+	int mode = 0644;
+	int err;
+	static char *kwlist[] = {"tdb_path", "tdb_flags", "open_flags", "mode", NULL};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|iii", kwlist,
+					 &tdb_path, &tdb_flags, &open_flags, &mode)) {
+		return NULL;
+	}
+
+	err = py_ctdb_db_synchronize(dbctx, tdb_path, tdb_flags, open_flags, mode);
+	if (err) {
+		return NULL;
+	}
+
+	Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(py_ctdb_db_iter__doc__,
+"iter() -> CtdbDBIterator\n"
+"------------------------\n"
+"Create an iterator for this database.\n"
+"\n"
+"Returns:\n"
+"    An iterator that yields (key, value) tuples for all records\n"
+"\n"
+"Raises:\n"
+"    ValueError: If the database is not persistent or replicated\n"
+"    CtdbError: If the iteration setup fails\n"
+);
+static PyObject *py_ctdb_db_iter(PyObject *self, PyObject *unused)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+
+	if (!(dbctx->db_flags &
+	      (CTDB_DB_FLAGS_PERSISTENT | CTDB_DB_FLAGS_REPLICATED))) {
+		PyErr_Format(PyExc_ValueError,
+			     "Database '%s' is not persistent or replicated",
+			     dbctx->db_name);
+		return NULL;
+	}
+
+	return py_ctdb_db_iter_new(dbctx);
+}
+
+PyDoc_STRVAR(py_ctdb_db_batch_op__doc__,
+"batch_op(operations) -> dict\n"
+"----------------------------\n"
+"Perform a batch of operations under a single transaction.\n"
+"\n"
+"Args:\n"
+"    operations: Iterable of BatchOp instances where each BatchOp contains:\n"
+"        action: str - 'GET', 'SET', or 'DEL'\n"
+"        key: bytes - The record key\n"
+"        value: bytes - The record value (required for SET, None for GET/DEL)\n"
+"\n"
+"Returns:\n"
+"    dict: Dictionary mapping operation index to value for all GET operations\n"
+"\n"
+"Raises:\n"
+"    TypeError: If operations are not BatchOp instances\n"
+"    ValueError: If the database is not persistent/replicated or invalid operation\n"
+"    CtdbError: If any operation fails (transaction is rolled back)\n"
+"\n"
+"Example:\n"
+"    from pyctdb import BatchOp\n"
+"    ops = [\n"
+"        BatchOp('SET', b'key1', b'value1'),\n"
+"        BatchOp('GET', b'key2', None),\n"
+"        BatchOp('DEL', b'key3', None),\n"
+"    ]\n"
+"    results = db.batch_op(ops)\n"
+);
+static PyObject *py_ctdb_db_batch_op(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	py_ctdb_db_ctx *dbctx = (py_ctdb_db_ctx *)self;
+	PyObject *operations = NULL;
+	PyObject *result_dict = NULL;
+	struct batch_state state = {0};
+	int err;
+	static char *kwlist[] = {"operations", NULL};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", kwlist, &operations)) {
+		return NULL;
+	}
+
+	if (!(dbctx->db_flags &
+	      (CTDB_DB_FLAGS_PERSISTENT | CTDB_DB_FLAGS_REPLICATED))) {
+		PyErr_Format(PyExc_ValueError,
+			     "Database '%s' is not persistent or replicated",
+			     dbctx->db_name);
+		return NULL;
+	}
+
+	/* Parse Python operations into C structures */
+	if (parse_batch_operations(operations, &state) != 0) {
+		return NULL;
+	}
+
+	if (state.num_ops == 0) {
+		/* Empty operation list - return empty dict */
+		free_batch_state(&state);
+		return PyDict_New();
+	}
+
+	/* Execute operations with GIL dropped */
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(dbctx->client);
+	err = execute_batch_operations(dbctx, &state);
+	PYCTDB_UNLOCK(dbctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err != 0) {
+		pyctdb_err(err, state.error.message);
+		free_batch_state(&state);
+		return NULL;
+	}
+
+	/* Build result dictionary from GET operations */
+	result_dict = build_batch_result_dict(&state);
+
+	/* Free allocated memory */
+	free_batch_state(&state);
+
+	return result_dict;
+}
+
+PyDoc_STRVAR(py_ctdb_db_name__doc__,
+"db_name -> str\n"
+"--------------\n"
+"The name of this CTDB database.\n"
+);
+
+static PyObject *py_ctdb_db_get_name(PyObject *self, void *closure)
+{
+	py_ctdb_db_ctx *ctx = (py_ctdb_db_ctx *)self;
+	return Py_BuildValue("s", ctx->db_name);
+}
+
+PyDoc_STRVAR(py_ctdb_db_id__doc__,
+"db_id -> int\n"
+"------------\n"
+"The database ID of this CTDB database.\n"
+);
+
+static PyObject *py_ctdb_db_get_id(PyObject *self, void *closure)
+{
+	py_ctdb_db_ctx *ctx = (py_ctdb_db_ctx *)self;
+	return Py_BuildValue("I", ctx->db_id);
+}
+
+PyDoc_STRVAR(py_ctdb_db_flags__doc__,
+"db_flags -> tuple[str, ...]\n"
+"---------------------------\n"
+"A tuple of flag names associated with this CTDB database.\n"
+);
+
+static PyObject *py_ctdb_db_get_flags(PyObject *self, void *closure)
+{
+	py_ctdb_db_ctx *ctx = (py_ctdb_db_ctx *)self;
+	PyObject *result = NULL;
+	PyObject *flag_list = NULL;
+	size_t i;
+
+	flag_list = PyList_New(0);
+	if (flag_list == NULL) {
+		return NULL;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(db_flags_tbl); i++) {
+		if (ctx->db_flags & db_flags_tbl[i].val) {
+			PyObject *flag_str = PyUnicode_FromString(db_flags_tbl[i].name);
+			if (flag_str == NULL) {
+				Py_DECREF(flag_list);
+				return NULL;
+			}
+			if (PyList_Append(flag_list, flag_str) < 0) {
+				Py_DECREF(flag_str);
+				Py_DECREF(flag_list);
+				return NULL;
+			}
+			Py_DECREF(flag_str);
+		}
+	}
+
+	result = PyList_AsTuple(flag_list);
+	Py_DECREF(flag_list);
+	return result;
+}
+
+static PyGetSetDef ctdb_db_getsetters[] = {
+	{
+		.name = discard_const_p(char, "db_name"),
+		.get = (getter)py_ctdb_db_get_name,
+		.doc = py_ctdb_db_name__doc__,
+	},
+	{
+		.name = discard_const_p(char, "db_id"),
+		.get = (getter)py_ctdb_db_get_id,
+		.doc = py_ctdb_db_id__doc__,
+	},
+	{
+		.name = discard_const_p(char, "db_flags"),
+		.get = (getter)py_ctdb_db_get_flags,
+		.doc = py_ctdb_db_flags__doc__,
+	},
+	{ .name = NULL }
+};
+
+static PyMethodDef ctdb_db_methods[] = {
+	{
+		.ml_name = "fetch",
+		.ml_meth = (PyCFunction)py_ctdb_db_fetch,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_db_fetch__doc__,
+	},
+	{
+		.ml_name = "store",
+		.ml_meth = (PyCFunction)py_ctdb_db_store,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_db_store__doc__,
+	},
+	{
+		.ml_name = "delete",
+		.ml_meth = (PyCFunction)py_ctdb_db_delete,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_db_delete__doc__,
+	},
+	{
+		.ml_name = "wipe_db",
+		.ml_meth = (PyCFunction)py_ctdb_db_wipe_db,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_ctdb_db_wipe_db__doc__,
+	},
+	{
+		.ml_name = "sync_with_tdb_file",
+		.ml_meth = (PyCFunction)py_ctdb_db_sync_with_tdb_file,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_db_sync_with_tdb_file__doc__,
+	},
+	{
+		.ml_name = "iter",
+		.ml_meth = (PyCFunction)py_ctdb_db_iter,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_ctdb_db_iter__doc__,
+	},
+	{
+		.ml_name = "batch_op",
+		.ml_meth = (PyCFunction)py_ctdb_db_batch_op,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_ctdb_db_batch_op__doc__,
+	},
+	{ NULL, NULL, 0, NULL }
+};
+
+PyTypeObject PyCtdbDB = {
+	.tp_name = PYMODULE_NAME ".CtdbDB",
+	.tp_basicsize = sizeof(py_ctdb_db_ctx),
+	.tp_methods = ctdb_db_methods,
+	.tp_getset = ctdb_db_getsetters,
+	.tp_doc = "A CTDB database",
+	.tp_new = PyType_GenericNew,
+	.tp_init = (initproc)py_ctdb_db_init,
+	.tp_dealloc = (destructor)py_ctdb_db_dealloc,
+	.tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,
+};
+
+PyObject *py_get_or_create_db(py_ctdb_client_ctx *client,
+			      const char *db_name,
+			      uint8_t db_flags_in,
+			      bool create_ok)
+{
+	struct ctdb_dbid_map *dbmap;
+	uint32_t db_id;
+	uint8_t db_flags = db_flags_in;
+	int err;
+	const char *errmsg;
+	TALLOC_CTX *tmp_ctx = NULL;
+	py_ctdb_db_ctx *pydb = NULL;
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(client);
+	tmp_ctx = talloc_new(client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		err = ENOMEM;
+		errmsg = "Memory allocation failure";
+	} else {
+		err = ctdb_ctrl_get_dbmap(tmp_ctx, client->ev, client->client,
+					  client->pnn, TIMEOUT(client), &dbmap);
+		if (err) {
+			errmsg = "Failed to get ctdb dbmap";
+		}
+	}
+
+	if (!err) {
+		/* check that this DB actually exists */
+		int i;
+		bool found = false;
+		const char *name;
+		for (i = 0; i < dbmap->num; i++) {
+			err = ctdb_ctrl_get_dbname(tmp_ctx,
+						   client->ev,
+						   client->client,
+						   client->pnn,
+						   TIMEOUT(client),
+						   dbmap->dbs[i].db_id,
+						   &name);
+			if (err) {
+				errmsg = "Failed to get dbname";
+				break;
+			}
+
+			if (strcmp(db_name, name) == 0) {
+				/*
+				 * If database already exists, use those flags
+				 * rather than user-supplied ones
+				 */
+				db_flags = dbmap->dbs[i].flags;
+				found = true;
+				break;
+			}
+		}
+
+		if (!found && !create_ok) {
+			err = ENOENT;
+			errmsg = "Database not found and create_ok not set";
+		}
+	}
+
+	TALLOC_FREE(tmp_ctx);
+	PYCTDB_UNLOCK(client);
+	Py_END_ALLOW_THREADS
+
+	if (err) {
+		pyctdb_err(err, errmsg);
+		return NULL;
+	}
+
+	pydb =  (py_ctdb_db_ctx *)PyObject_CallFunction((PyObject *)&PyCtdbDB, NULL);
+	if (pydb == NULL)
+		return NULL;
+
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(client);
+	err = ctdb_attach(client->ev, client->client, TIMEOUT(client),
+			  db_name, db_flags, &pydb->db);
+	PYCTDB_UNLOCK(client);
+	Py_END_ALLOW_THREADS
+
+	if (err) {
+		Py_DECREF(pydb);
+		pyctdb_err(err, errmsg);
+		return NULL;
+	}
+
+	pydb->client = (py_ctdb_client_ctx *)Py_NewRef(client);
+	strlcpy(pydb->db_name, db_name, sizeof(pydb->db_name));
+	pydb->db_id = pydb->db->db_id;
+	pydb->db_flags = pydb->db->db_flags;
+	return (PyObject *)pydb;
+}

--- a/ctdb/pyclient/pyclient_db_batch.c
+++ b/ctdb/pyclient/pyclient_db_batch.c
@@ -1,0 +1,440 @@
+/*
+   CTDB python client - Database Batch Operations
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pyclient.h"
+
+static PyStructSequence_Field batch_op_fields[] = {
+	{
+		.name = "action",
+		.doc = "Operation action: 'GET', 'SET', or 'DEL'",
+	},
+	{
+		.name = "key",
+		.doc = "Record key as bytes",
+	},
+	{
+		.name = "value",
+		.doc = "Record value as bytes (required for SET, ignored for GET/DEL)",
+	},
+	{ .name = NULL }
+};
+
+static PyStructSequence_Desc batch_op_desc = {
+	.name = PYMODULE_NAME ".BatchOp",
+	.doc = "Batch operation tuple (action, key, value)",
+	.fields = batch_op_fields,
+	.n_in_sequence = 3,
+};
+
+bool setup_batch_op_type(PyObject *module_ref)
+{
+	pyctdb_mod_state_t *state = pyctdb_get_state(module_ref);
+	PyTypeObject *batch_op_type;
+
+	batch_op_type = PyMem_RawMalloc(sizeof(PyTypeObject));
+	if (batch_op_type == NULL) {
+		PyErr_NoMemory();
+		return false;
+	}
+
+	if (PyStructSequence_InitType2(batch_op_type, &batch_op_desc) < 0) {
+		PyMem_RawFree(batch_op_type);
+		return false;
+	}
+
+	state->py_batch_op_type = batch_op_type;
+
+	if (PyModule_AddObjectRef(module_ref, "BatchOp", (PyObject *)batch_op_type) < 0) {
+		return false;
+	}
+
+	return true;
+}
+
+void free_batch_state(struct batch_state *state)
+{
+	size_t i;
+
+	if (state->ops != NULL) {
+		for (i = 0; i < state->num_ops; i++) {
+			PyMem_RawFree(state->ops[i].key.dptr);
+			if (state->ops[i].value.dptr != NULL) {
+				PyMem_RawFree(state->ops[i].value.dptr);
+			}
+		}
+		PyMem_RawFree(state->ops);
+		state->ops = NULL;
+	}
+
+	if (state->results != NULL) {
+		for (i = 0; i < state->num_ops; i++) {
+			if (state->results[i] != NULL) {
+				TDB_DATA *result_data = (TDB_DATA *)state->results[i];
+				PyMem_RawFree(result_data->dptr);
+				PyMem_RawFree(result_data);
+				state->results[i] = NULL;
+			}
+		}
+		PyMem_RawFree(state->results);
+		state->results = NULL;
+	}
+
+	state->num_ops = 0;
+	state->capacity = 0;
+}
+
+int parse_batch_operations(PyObject *operations, struct batch_state *state)
+{
+	PyObject *iterator = NULL;
+	PyObject *item = NULL;
+	int ret = -1;
+
+	state->capacity = 16;
+	state->num_ops = 0;
+
+	/* Allocate initial arrays */
+	state->ops = PyMem_RawMalloc(state->capacity * sizeof(struct batch_operation));
+	state->results = PyMem_RawMalloc(state->capacity * sizeof(PyObject *));
+	if (state->ops == NULL || state->results == NULL) {
+		PyErr_NoMemory();
+		goto cleanup;
+	}
+	memset(state->results, 0, state->capacity * sizeof(PyObject *));
+
+	/* Get iterator for the operations */
+	iterator = PyObject_GetIter(operations);
+	if (iterator == NULL) {
+		PyErr_SetString(PyExc_TypeError, "operations must be iterable");
+		goto cleanup;
+	}
+
+	/* Parse operations from Python objects */
+	while ((item = PyIter_Next(iterator)) != NULL) {
+		const char *action_str;
+		Py_ssize_t key_len, val_len = 0;
+		uint8_t *key_data, *val_data = NULL;
+		struct batch_operation *op;
+		PyObject *action_obj, *key_obj, *value_obj;
+		pyctdb_mod_state_t *mod_state = pyctdb_get_state(NULL);
+
+		/* Expand capacity if needed */
+		if (state->num_ops >= state->capacity) {
+			size_t new_capacity = state->capacity * 2;
+			struct batch_operation *new_ops;
+			PyObject **new_results;
+
+			new_ops = PyMem_RawRealloc(state->ops,
+						   new_capacity * sizeof(struct batch_operation));
+			new_results = PyMem_RawRealloc(state->results,
+						       new_capacity * sizeof(PyObject *));
+
+			if (new_ops == NULL || new_results == NULL) {
+				PyMem_RawFree(new_ops);
+				PyMem_RawFree(new_results);
+				PyErr_NoMemory();
+				Py_DECREF(item);
+				goto cleanup;
+			}
+
+			memset(&new_results[state->capacity], 0,
+			       (new_capacity - state->capacity) * sizeof(PyObject *));
+
+			state->ops = new_ops;
+			state->results = new_results;
+			state->capacity = new_capacity;
+		}
+
+		/* Check if it's our BatchOp struct sequence type */
+		if (!PyObject_IsInstance(item, (PyObject *)mod_state->py_batch_op_type)) {
+			Py_DECREF(item);
+			PyErr_SetString(PyExc_TypeError,
+					"Each operation must be a BatchOp instance");
+			goto cleanup;
+		}
+
+		/* Access struct sequence fields directly */
+		action_obj = PyStructSequence_GET_ITEM(item, 0);
+		key_obj = PyStructSequence_GET_ITEM(item, 1);
+		value_obj = PyStructSequence_GET_ITEM(item, 2);
+
+		/* Extract action string */
+		if (!PyUnicode_Check(action_obj)) {
+			Py_DECREF(item);
+			PyErr_SetString(PyExc_TypeError, "action must be a string");
+			goto cleanup;
+		}
+		action_str = PyUnicode_AsUTF8(action_obj);
+		if (action_str == NULL) {
+			Py_DECREF(item);
+			goto cleanup;
+		}
+
+		/* Extract key bytes */
+		if (PyBytes_AsStringAndSize(key_obj, (char **)&key_data, &key_len) < 0) {
+			Py_DECREF(item);
+			goto cleanup;
+		}
+
+		/* Extract value bytes (may be None) */
+		if (value_obj != Py_None) {
+			if (PyBytes_AsStringAndSize(value_obj, (char **)&val_data, &val_len) < 0) {
+				Py_DECREF(item);
+				goto cleanup;
+			}
+		} else {
+			val_data = NULL;
+			val_len = 0;
+		}
+
+		op = &state->ops[state->num_ops];
+
+		/* Parse action */
+		if (strcmp(action_str, "GET") == 0) {
+			op->action = BATCH_ACTION_GET;
+		} else if (strcmp(action_str, "SET") == 0) {
+			op->action = BATCH_ACTION_SET;
+		} else if (strcmp(action_str, "DEL") == 0) {
+			op->action = BATCH_ACTION_DEL;
+		} else {
+			Py_DECREF(item);
+			PyErr_Format(PyExc_ValueError,
+				     "Invalid action '%s', must be GET, SET, or DEL",
+				     action_str);
+			goto cleanup;
+		}
+
+		/* Copy key */
+		op->key.dptr = PyMem_RawMalloc(key_len);
+		if (op->key.dptr == NULL) {
+			Py_DECREF(item);
+			PyErr_NoMemory();
+			goto cleanup;
+		}
+		memcpy(op->key.dptr, key_data, key_len);
+		op->key.dsize = key_len;
+
+		/* Copy value for SET operations */
+		if (op->action == BATCH_ACTION_SET) {
+			if (val_data == NULL || val_len == 0) {
+				Py_DECREF(item);
+				PyErr_SetString(PyExc_ValueError,
+						"SET operation requires non-empty value");
+				PyMem_RawFree(op->key.dptr);
+				op->key.dptr = NULL;
+				goto cleanup;
+			}
+			op->value.dptr = PyMem_RawMalloc(val_len);
+			if (op->value.dptr == NULL) {
+				PyMem_RawFree(op->key.dptr);
+				op->key.dptr = NULL;
+				Py_DECREF(item);
+				PyErr_NoMemory();
+				goto cleanup;
+			}
+			memcpy(op->value.dptr, val_data, val_len);
+			op->value.dsize = val_len;
+		} else {
+			op->value.dptr = NULL;
+			op->value.dsize = 0;
+		}
+
+		state->num_ops++;
+		Py_DECREF(item);
+	}
+
+	if (PyErr_Occurred()) {
+		goto cleanup;
+	}
+
+	ret = 0;
+
+cleanup:
+	if (iterator != NULL) {
+		Py_DECREF(iterator);
+	}
+
+	if (ret != 0) {
+		free_batch_state(state);
+	}
+
+	return ret;
+}
+
+int execute_batch_operations(py_ctdb_db_ctx *pydb,
+			      struct batch_state *state)
+{
+	struct ctdb_transaction_handle *h = NULL;
+	TALLOC_CTX *tmp_ctx;
+	int err = 0;
+	size_t i;
+
+	tmp_ctx = talloc_new(pydb->client->mem_ctx);
+	if (tmp_ctx == NULL) {
+		pyctdb_set_error(&state->error, ENOMEM,
+				 "Failed to allocate memory context");
+		return ENOMEM;
+	}
+
+	err = ctdb_transaction_start(tmp_ctx, pydb->client->ev,
+				     pydb->client->client,
+				     TIMEOUT(pydb->client),
+				     pydb->db, false, &h);
+	if (err != 0) {
+		pyctdb_set_error(&state->error, err, "Failed to start transaction");
+		goto done;
+	}
+
+	for (i = 0; i < state->num_ops; i++) {
+		struct batch_operation *op = &state->ops[i];
+
+		switch (op->action) {
+		case BATCH_ACTION_GET:
+		{
+			TDB_DATA result = {0};
+			err = ctdb_transaction_fetch_record(h, op->key,
+							    tmp_ctx, &result);
+			if (err != 0) {
+				pyctdb_set_error(&state->error, err,
+						 "Failed to fetch record in batch operation %zu", i);
+				goto cancel;
+			}
+
+			if (result.dptr == NULL) {
+				pyctdb_set_error(&state->error, ENOENT,
+						 "Record not found in batch operation %zu", i);
+				err = ENOENT;
+				goto cancel;
+			}
+
+			/* Allocate result using PyMem for Python */
+			if (result.dsize > 0) {
+				TDB_DATA *result_copy = PyMem_RawMalloc(sizeof(TDB_DATA));
+				if (result_copy == NULL) {
+					err = ENOMEM;
+					pyctdb_set_error(&state->error, ENOMEM,
+							 "Failed to allocate memory for result");
+					goto cancel;
+				}
+
+				result_copy->dptr = PyMem_RawMalloc(result.dsize);
+				if (result_copy->dptr == NULL) {
+					PyMem_RawFree(result_copy);
+					err = ENOMEM;
+					pyctdb_set_error(&state->error, ENOMEM,
+							 "Failed to allocate memory for result data");
+					goto cancel;
+				}
+
+				memcpy(result_copy->dptr, result.dptr, result.dsize);
+				result_copy->dsize = result.dsize;
+				state->results[i] = (PyObject *)result_copy;
+			}
+			break;
+		}
+		case BATCH_ACTION_SET:
+			err = ctdb_transaction_store_record(h, op->key, op->value);
+			if (err != 0) {
+				pyctdb_set_error(&state->error, err,
+						 "Failed to store record in batch operation %zu", i);
+				goto cancel;
+			}
+			break;
+
+		case BATCH_ACTION_DEL:
+			err = ctdb_transaction_delete_record(h, op->key);
+			if (err != 0) {
+				pyctdb_set_error(&state->error, err,
+						 "Failed to delete record in batch operation %zu", i);
+				goto cancel;
+			}
+			break;
+
+		default:
+			pyctdb_set_error(&state->error, EINVAL,
+					 "Unknown batch action %d in operation %zu",
+					 op->action, i);
+			err = EINVAL;
+			goto cancel;
+		}
+	}
+
+	err = ctdb_transaction_commit(h);
+	if (err != 0) {
+		pyctdb_set_error(&state->error, err, "Failed to commit transaction");
+		goto cancel;
+	}
+
+	TALLOC_FREE(tmp_ctx);
+	return 0;
+
+cancel:
+	ctdb_transaction_cancel(h);
+done:
+	TALLOC_FREE(tmp_ctx);
+	return err;
+}
+
+PyObject *build_batch_result_dict(struct batch_state *state)
+{
+	PyObject *result_dict;
+	size_t i;
+
+	result_dict = PyDict_New();
+	if (result_dict == NULL) {
+		return NULL;
+	}
+
+	for (i = 0; i < state->num_ops; i++) {
+		if (state->ops[i].action == BATCH_ACTION_GET && state->results[i] != NULL) {
+			TDB_DATA *result_data = (TDB_DATA *)state->results[i];
+			PyObject *py_value;
+			PyObject *py_index;
+
+			py_value = PyBytes_FromStringAndSize(
+				(const char *)result_data->dptr,
+				result_data->dsize
+			);
+			PyMem_RawFree(result_data->dptr);
+			PyMem_RawFree(result_data);
+			state->results[i] = NULL;
+
+			if (py_value == NULL) {
+				Py_DECREF(result_dict);
+				return NULL;
+			}
+
+			py_index = PyLong_FromSize_t(i);
+			if (py_index == NULL) {
+				Py_DECREF(py_value);
+				Py_DECREF(result_dict);
+				return NULL;
+			}
+
+			if (PyDict_SetItem(result_dict, py_index, py_value) < 0) {
+				Py_DECREF(py_index);
+				Py_DECREF(py_value);
+				Py_DECREF(result_dict);
+				return NULL;
+			}
+
+			Py_DECREF(py_index);
+			Py_DECREF(py_value);
+		}
+	}
+
+	return result_dict;
+}

--- a/ctdb/pyclient/pyclient_db_iter.c
+++ b/ctdb/pyclient/pyclient_db_iter.c
@@ -1,0 +1,248 @@
+/*
+   CTDB python client - Database Iterator
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pyclient.h"
+
+/*
+ * Iterator state structure for database iteration
+ */
+typedef struct {
+	PyObject_HEAD;
+	py_ctdb_db_ctx *db_ctx;
+	TDB_DATA *keys;
+	size_t num_keys;
+	size_t current_index;
+} py_ctdb_db_iter_ctx;
+
+/*
+ * Callback for traverse - collects keys into a list
+ */
+struct key_collection_state {
+	TDB_DATA *keys;
+	size_t num_keys;
+	size_t capacity;
+	bool error_occurred;
+};
+
+static int collect_keys_callback(uint32_t reqid,
+				  struct ctdb_ltdb_header *header,
+				  TDB_DATA key,
+				  TDB_DATA data,
+				  void *private_data)
+{
+	struct key_collection_state *state =
+		(struct key_collection_state *)private_data;
+
+	/* Skip empty or deleted records */
+	if (key.dsize == 0 || data.dptr == NULL) {
+		return 0;
+	}
+
+	/* Skip the sequence number key for persistent databases */
+	if (key.dsize == (strlen(CTDB_DB_SEQNUM_KEY) + 1) &&
+	    memcmp(key.dptr, CTDB_DB_SEQNUM_KEY, key.dsize) == 0) {
+		return 0;
+	}
+
+	/* Expand capacity if needed */
+	if (state->num_keys >= state->capacity) {
+		size_t new_capacity = state->capacity * 2;
+		if (new_capacity == 0) {
+			new_capacity = 64;
+		}
+
+		TDB_DATA *new_keys = PyMem_RawRealloc(state->keys,
+						      new_capacity * sizeof(TDB_DATA));
+		if (new_keys == NULL) {
+			state->error_occurred = true;
+			return ENOMEM;
+		}
+
+		/* Zero out the newly allocated portion for security */
+		memset(&new_keys[state->capacity], 0,
+		       (new_capacity - state->capacity) * sizeof(TDB_DATA));
+
+		state->keys = new_keys;
+		state->capacity = new_capacity;
+	}
+
+	/* Copy the key */
+	state->keys[state->num_keys].dptr = PyMem_RawMalloc(key.dsize);
+	if (state->keys[state->num_keys].dptr == NULL) {
+		state->error_occurred = true;
+		return ENOMEM;
+	}
+
+	memcpy(state->keys[state->num_keys].dptr, key.dptr, key.dsize);
+	state->keys[state->num_keys].dsize = key.dsize;
+	state->num_keys++;
+
+	return 0;
+}
+
+/*
+ * Create iterator for a database
+ */
+PyObject *py_ctdb_db_iter_new(py_ctdb_db_ctx *db_ctx)
+{
+	py_ctdb_db_iter_ctx *iter_ctx = NULL;
+	struct key_collection_state state = {0};
+	int err;
+
+	if (db_ctx->db == NULL) {
+		PyErr_SetString(PyExc_ValueError, "Database context not initialized");
+		return NULL;
+	}
+
+	/* Collect all keys via traverse */
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(db_ctx->client);
+	err = ctdb_db_traverse_local(db_ctx->db, true, false,
+				     collect_keys_callback, &state);
+	PYCTDB_UNLOCK(db_ctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err != 0 || state.error_occurred) {
+		/* Clean up any allocated keys */
+		size_t i;
+		for (i = 0; i < state.num_keys; i++) {
+			PyMem_RawFree(state.keys[i].dptr);
+		}
+		PyMem_RawFree(state.keys);
+
+		if (state.error_occurred) {
+			PyErr_NoMemory();
+		} else {
+			pyctdb_err(err, "Failed to traverse database");
+		}
+		return NULL;
+	}
+
+	/* Create the iterator object */
+	iter_ctx = PyObject_New(py_ctdb_db_iter_ctx, &PyCtdbDBIter);
+	if (iter_ctx == NULL) {
+		size_t i;
+		for (i = 0; i < state.num_keys; i++) {
+			PyMem_RawFree(state.keys[i].dptr);
+		}
+		PyMem_RawFree(state.keys);
+		return NULL;
+	}
+
+	iter_ctx->db_ctx = (py_ctdb_db_ctx *)Py_NewRef(db_ctx);
+	iter_ctx->keys = state.keys;
+	iter_ctx->num_keys = state.num_keys;
+	iter_ctx->current_index = 0;
+
+	return (PyObject *)iter_ctx;
+}
+
+static void py_ctdb_db_iter_dealloc(py_ctdb_db_iter_ctx *self)
+{
+	size_t i;
+
+	/* Free all collected keys */
+	for (i = 0; i < self->num_keys; i++) {
+		PyMem_RawFree(self->keys[i].dptr);
+	}
+	PyMem_RawFree(self->keys);
+
+	Py_CLEAR(self->db_ctx);
+	PyObject_Del(self);
+}
+
+static PyObject *py_ctdb_db_iter_iter(PyObject *self)
+{
+	Py_INCREF(self);
+	return self;
+}
+
+static PyObject *py_ctdb_db_iter_next(PyObject *self)
+{
+	py_ctdb_db_iter_ctx *iter_ctx = (py_ctdb_db_iter_ctx *)self;
+	TDB_DATA key, data = {0};
+	PyObject *py_key = NULL;
+	PyObject *py_value = NULL;
+	PyObject *result = NULL;
+	pyctdb_error_t pyerr;
+	int err;
+
+	/* Check if we've exhausted all keys */
+	if (iter_ctx->current_index >= iter_ctx->num_keys) {
+		PyErr_SetNone(PyExc_StopIteration);
+		return NULL;
+	}
+
+	key = iter_ctx->keys[iter_ctx->current_index];
+	iter_ctx->current_index++;
+
+	/* Fetch the value for this key */
+	Py_BEGIN_ALLOW_THREADS
+	PYCTDB_LOCK(iter_ctx->db_ctx->client);
+	err = py_ctdb_fetchrecord(iter_ctx->db_ctx, key, &data, &pyerr);
+	PYCTDB_UNLOCK(iter_ctx->db_ctx->client);
+	Py_END_ALLOW_THREADS
+
+	if (err != 0) {
+		if (err == ENOENT) {
+			/* Key was deleted between traverse and fetch - skip it */
+			return py_ctdb_db_iter_next(self);
+		}
+		pyctdb_err(err, pyerr.message);
+		return NULL;
+	}
+
+	/* Build Python key and value */
+	py_key = PyBytes_FromStringAndSize((const char *)key.dptr, key.dsize);
+	if (py_key == NULL) {
+		PyMem_RawFree(data.dptr);
+		return NULL;
+	}
+
+	py_value = PyBytes_FromStringAndSize((const char *)data.dptr, data.dsize);
+	PyMem_RawFree(data.dptr);
+
+	if (py_value == NULL) {
+		Py_DECREF(py_key);
+		return NULL;
+	}
+
+	/* Return tuple of (key, value) */
+	result = PyTuple_Pack(2, py_key, py_value);
+	Py_DECREF(py_key);
+	Py_DECREF(py_value);
+
+	return result;
+}
+
+PyDoc_STRVAR(py_ctdb_db_iter__doc__,
+"Iterator for CTDB database records.\n"
+"\n"
+"Yields tuples of (key, value) for each record in the database.\n"
+"The iterator snapshot is taken at creation time, so records added\n"
+"after iteration begins will not be included.\n"
+);
+
+PyTypeObject PyCtdbDBIter = {
+	.tp_name = PYMODULE_NAME ".CtdbDBIterator",
+	.tp_basicsize = sizeof(py_ctdb_db_iter_ctx),
+	.tp_doc = py_ctdb_db_iter__doc__,
+	.tp_dealloc = (destructor)py_ctdb_db_iter_dealloc,
+	.tp_iter = py_ctdb_db_iter_iter,
+	.tp_iternext = py_ctdb_db_iter_next,
+	.tp_flags = Py_TPFLAGS_DEFAULT,
+};

--- a/ctdb/pyclient/pyclient_error.c
+++ b/ctdb/pyclient/pyclient_error.c
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include <string.h>
+#include "pyclient.h"
+
+PyDoc_STRVAR(py_ctdb_exception__doc__,
+"CTDBError(Exception)\n"
+"-----------------------\n\n"
+"Python wrapper around an unexpected CTDB response.\n\n"
+"attributes:\n"
+"-----------\n"
+"errno: int\n"
+"    Errno returned by the CTDB client\n"
+"err_str: str\n"
+"    strerror() of the errno\n"
+"message: str\n"
+"    verbose message describing the error\n"
+"location: str\n"
+"    line of file in uncompiled source of this module\n\n"
+);
+bool setup_ctdb_exception(PyObject *module_ref)
+{
+	pyctdb_mod_state_t *state = NULL;
+	PyObject *ctdb_error = NULL;
+	PyObject *dict = NULL;
+	bool success = false;
+
+	// Set up spec for the new exception type
+	dict = Py_BuildValue("{s:i,s:s,s:s,s:s}",
+			     "code", 0,
+			     "err_str", "",
+			     "message", "",
+			     "location", "");
+	if (dict == NULL) {
+		goto cleanup;
+	}
+
+	ctdb_error = PyErr_NewExceptionWithDoc(PYMODULE_NAME
+					       ".CTDBError",
+					       py_ctdb_exception__doc__,
+					       PyExc_RuntimeError,
+					       dict);
+	if (ctdb_error == NULL) {
+		goto cleanup;
+	}
+
+	state = pyctdb_get_state(module_ref);
+	if (state == NULL) {
+		goto cleanup;
+	}
+
+	// Add reference to our module state so that it's available generally
+	// for implementation in this extension
+	state->py_ctdb_error = Py_NewRef(ctdb_error);
+
+	// Add exception reference to root of module so that it's available
+	// to library consumers
+	if (PyModule_AddObjectRef(module_ref, "CTDBError", ctdb_error) < 0) {
+		goto cleanup;
+	}
+
+	success = true;
+
+cleanup:
+	Py_CLEAR(dict);
+	Py_CLEAR(ctdb_error);
+	return success;
+}
+
+void
+_set_ctdb_exc(int code, const char *additional_info, const char *location)
+{
+	pyctdb_mod_state_t *state = NULL;
+	PyObject *obj = NULL;
+	PyObject *exc = NULL;
+	PyObject *message = NULL;
+	const char *err_str = strerror(code);
+
+	state = pyctdb_get_state(NULL);
+
+	// first set up str() for exception
+	message = PyUnicode_FromFormat("[%d]: %s", code, additional_info);
+	if (message == NULL) {
+		return;
+	}
+
+	PYCTDB_ASSERT((state->py_ctdb_error != NULL), "Error not initialized");
+	exc = PyObject_CallOneArg(state->py_ctdb_error, message);
+	Py_CLEAR(message);
+	if (exc == NULL) {
+		return;
+	}
+
+	// Create integer object for the code value
+	obj = PyLong_FromLong(code);
+	if (obj == NULL) {
+		Py_CLEAR(exc);
+		return;
+	}
+
+	PyObject_SetAttrString(exc, "errno", obj);
+	Py_CLEAR(obj);
+
+	/* set err_str */
+	obj = PyUnicode_FromString(err_str);
+	if (obj == NULL) {
+		Py_CLEAR(exc);
+		return;
+	}
+
+	PyObject_SetAttrString(exc, "err_str", obj);
+	Py_CLEAR(obj);
+
+	/* set message */
+	obj = PyUnicode_FromString(additional_info);
+	if (obj == NULL) {
+		Py_CLEAR(exc);
+		return;
+	}
+
+	PyObject_SetAttrString(exc, "message", obj);
+	Py_CLEAR(obj);
+
+	/* set location */
+	obj = PyUnicode_FromString(location);
+	if (obj == NULL) {
+		Py_CLEAR(exc);
+		return;
+	}
+
+	PyObject_SetAttrString(exc, "location", obj);
+	Py_CLEAR(obj);
+
+	PyErr_SetObject(state->py_ctdb_error, exc);
+	Py_DECREF(exc);
+}
+
+void
+_pyctdb_set_error(pyctdb_error_t *error, int error_code, const char *fmt,
+		  const char *location, ...)
+{
+        va_list args;
+        int offset = 0;
+
+        if (!error || !fmt) {
+		abort();
+        }
+
+        va_start(args, location);
+        offset = vsnprintf(error->message, sizeof(error->message), fmt, args);
+        va_end(args);
+
+        if (offset > 0 && (size_t)offset < sizeof(error->message) - 1) {
+                snprintf(error->message + offset, sizeof(error->message) - offset,
+                        " [%s]", location);
+        }
+
+	error->code = error_code;
+}

--- a/ctdb/pyclient/pyclient_module.c
+++ b/ctdb/pyclient/pyclient_module.c
@@ -1,0 +1,225 @@
+/*
+   CTDB python client
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pyclient.h"
+
+static int
+pyctdb_clear(PyObject *m)
+{
+	pyctdb_mod_state_t *state = NULL;
+
+	if (m == NULL) {
+		return 0;
+	}
+
+	state = pyctdb_get_state(m);
+	PYCLEAR_MOD_STATE(state);
+	return 0;
+}
+
+static void
+pyctdb_free(void *m)
+{
+	pyctdb_clear((PyObject *)m);
+}
+
+PyDoc_STRVAR(pyctdb_get_global_locking__doc__,
+"get_global_locking() -> bool\n"
+"----------------------------\n"
+"Get the current global locking state for the pyctdb module.\n"
+"When global locking is enabled, then each ctdb client operation will be\n"
+"serialized behind a global pthread mutex for the module. The primary\n"
+"reason why global locking would be enabled is that the user has enabled\n"
+"the talloc library feature to generate a leak report on close.\n"
+);
+static PyObject *pyctdb_get_global_locking(PyObject *self, PyObject *unused)
+{
+	if (_Py_atomic_load_uint(&glock_enabled)) {
+		Py_RETURN_TRUE;
+	} else {
+		Py_RETURN_FALSE;
+	}
+}
+
+PyDoc_STRVAR(pyctdb_set_global_locking__doc__,
+"set_global_locking(value: bool) -> bool\n"
+"---------------------------------------\n"
+"Set the global locking behavior for ctdb client operations. \n"
+"See discussion in `get_global_locking()` for explanation of feature.\n"
+"\n"
+"Once leak reporting has been enabled, this feature may no longer be\n"
+"disabled for the module.\n"
+);
+static PyObject *pyctdb_set_global_locking(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	bool enable = false;
+	static char *kwlist[] = {"value", NULL};
+
+	if (PyArg_ParseTupleAndKeywords(args, kwargs, "p", kwlist, &enable) < 0) {
+		return NULL;
+	}
+
+	if (leak_reporting_enabled) {
+		PyErr_SetString(PyExc_ValueError,
+				"value may not be changed once "
+				"leak reporting has been enabled.");
+		return NULL;
+	}
+
+	_Py_atomic_store_uint(&glock_enabled, enable);
+
+	if (enable) {
+		Py_RETURN_TRUE;
+	} else {
+		Py_RETURN_FALSE;
+	}
+}
+
+PyDoc_STRVAR(pyctdb_get_leakreporting__doc__,
+"get_leak_reporting() -> bool\n"
+"----------------------------\n"
+"Return boolean indicating whether leak reporting for the python module\n"
+"is enabled. This is a developer-oriented module feature to aid in tracking\n"
+"talloc library memory usage at program exit.\n"
+);
+static PyObject *pyctdb_get_leakreporting(PyObject *self, PyObject *unused)
+{
+	if (_Py_atomic_load_uint(&leak_reporting_enabled)) {
+		Py_RETURN_TRUE;
+	} else {
+		Py_RETURN_FALSE;
+	}
+}
+
+PyDoc_STRVAR(pyctdb_enable_leakreporting__doc__,
+"enable_leak_reporting() -> None\n"
+"-------------------------------\n"
+"Enable talloc leak report for this module on program exit. This is a\n"
+"developer-oriented feature that should not be used in production scripts.\n"
+);
+static PyObject *pyctdb_enable_leakreporting(PyObject *self, PyObject *args)
+{
+	_Py_atomic_store_uint(&leak_reporting_enabled, 1);
+	_Py_atomic_store_uint(&glock_enabled, 1);
+	talloc_enable_leak_report_full();
+	Py_RETURN_NONE;
+}
+
+static PyMethodDef pyctdb_module_methods[] = {
+	{
+		.ml_name = "get_global_locking",
+		.ml_meth = (PyCFunction)pyctdb_get_global_locking,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = pyctdb_get_global_locking__doc__,
+	},
+	{
+		.ml_name = "set_global_locking",
+		.ml_meth = (PyCFunction)pyctdb_set_global_locking,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = pyctdb_set_global_locking__doc__,
+	},
+	{
+		.ml_name = "get_leak_reporting",
+		.ml_meth = (PyCFunction)pyctdb_get_leakreporting,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = pyctdb_get_leakreporting__doc__,
+	},
+	{
+		.ml_name = "enable_leak_reporting",
+		.ml_meth = (PyCFunction)pyctdb_enable_leakreporting,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = pyctdb_enable_leakreporting__doc__,
+	},
+	{ NULL, NULL, 0, NULL }
+};
+
+PyDoc_STRVAR(pyctdb_module_doc,
+"CTDB client cpython extension. \n"
+"\n"
+"This provides basic functionality to view the status of CTDB nodes and\n"
+"databases as well as perform basic administrative actions on the CTDB\n"
+"cluster.\n"
+);
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = PYMODULE_NAME,
+    .m_doc = pyctdb_module_doc,
+    .m_size = sizeof(pyctdb_mod_state_t),
+    .m_clear = pyctdb_clear,
+    .m_free = pyctdb_free,
+    .m_methods = pyctdb_module_methods,
+};
+
+/* Get the module state. NULL for module_in is OK, but less efficient */
+pyctdb_mod_state_t *pyctdb_get_state(PyObject *module_in)
+{
+	PyObject *modref = module_in;
+	pyctdb_mod_state_t *state = NULL;
+
+	if (modref == NULL) {
+		modref = PyState_FindModule(&moduledef);
+		PYCTDB_ASSERT((modref != NULL), "Failed to get module");
+	}
+
+	state = (pyctdb_mod_state_t *)PyModule_GetState(modref);
+	PYCTDB_ASSERT((state != NULL), "Failed to get module state");
+	return state;
+}
+
+PyObject* module_init(void);
+PyObject* module_init(void)
+{
+	PyObject *m = NULL;
+
+	if (PyType_Ready(&PyCtdbClient) < 0)
+		return NULL;
+
+	if (PyType_Ready(&PyCtdbDB) < 0)
+		return NULL;
+
+	if (PyType_Ready(&PyCtdbDBIter) < 0)
+		return NULL;
+
+	m = PyModule_Create(&moduledef);
+	if (m == NULL) {
+		fprintf(stderr, "Failed to initialize module\n");
+		return NULL;
+	}
+
+	if (!setup_ctdb_exception(m)) {
+		Py_DECREF(m);
+		return NULL;
+	}
+
+	if (!setup_batch_op_type(m)) {
+		Py_DECREF(m);
+		return NULL;
+	}
+
+	if (PyModule_AddObjectRef(m, "Client", (PyObject *)&PyCtdbClient) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+
+	return m;
+}
+
+PyMODINIT_FUNC PyInit_pyctdb(void)
+{
+    return module_init();
+}

--- a/ctdb/pyclient/pyclient_tables.h
+++ b/ctdb/pyclient/pyclient_tables.h
@@ -1,0 +1,73 @@
+#ifndef PYCLIENT_TABLES_H
+#define PYCLIENT_TABLES_H
+#include "pyclient.h"
+
+/*
+ * We will use intlags_enum_entry_t to construct python enum.IntFlag enum
+ * instances on module load and store them in our module state as well as
+ * having object references at root of module itself.
+ */
+typedef struct { uint32_t val; const char *name; } intflags_enum_entry_t;
+
+/*
+ * Lookup table to create pyctdb.NodeFlags IntFlags enum
+ * These are defined in protocol/protocol.h
+ *
+ * NODE_FLAGS_DISABLED and NODE_FLAGS_INACTIVE are handled during enum
+ * construction.
+ */
+static const intflags_enum_entry_t node_flags_tbl[] = {
+	/* 0x00000001 -- node isn't connected */
+	{ NODE_FLAGS_DISCONNECTED, "DISCONNECTED" },
+	/* 0x00000002 -- monitoring says node is unhealthy */
+	{ NODE_FLAGS_UNHEALTHY, "UNHEALTHY" },
+	/* 0x00000004 -- administrator has disabled node */
+	{ NODE_FLAGS_PERMANENTLY_DISABLED, "PERMANENTLY_DISABLED" },
+	/* 0x00000008 -- recovery daemon has banned the node */
+	{ NODE_FLAGS_BANNED, "BANNED" },
+	/* 0x00000010 -- this node has been deleted */
+	{ NODE_FLAGS_DELETED, "DELETED" },
+	/* 0x00000020 -- this node has been stopped */
+	{ NODE_FLAGS_STOPPED, "STOPPED" },
+};
+
+_Static_assert(
+	NODE_FLAGS_LAST == NODE_FLAGS_STOPPED,
+	"pyctdb node flags table needs to be updated"
+);
+
+/* Lookup table to create pyctdb.CtdbDbFlags python enum.IntFlag enum */
+static const intflags_enum_entry_t db_flags_tbl[] = {
+	{ CTDB_DB_FLAGS_PERSISTENT, "PERSISTENT" },	/* 0x01 */
+	{ CTDB_DB_FLAGS_READONLY, "READONLY" },		/* 0x02 */
+	{ CTDB_DB_FLAGS_STICKY, "STICKY" },		/* 0x04 */
+	{ CTDB_DB_FLAGS_REPLICATED, "REPLICATED" },	/* 0x08 */
+};
+
+_Static_assert(
+	CTDB_DB_FLAGS_LAST == CTDB_DB_FLAGS_REPLICATED,
+	"pyctdb db flags table needs to be updated"
+);
+
+/*
+ * pyctdb.CapFlags python enum.IntFlag enum basis
+ * These are defined in protocol/protocol.h
+ *
+ * CTBD_CAP_FEATURES and CTDB_CAP_DEFAULT will be defined when creating the
+ * actual enum and inserted as an object reference in module.
+ */
+static const intflags_enum_entry_t cap_flags_tbl[] = {
+	{ CTDB_CAP_RECMASTER, "RECMASTER" },
+	{ CTDB_CAP_LMASTER, "LMASTER" },
+	{ CTDB_CAP_LVS, "LVS" },		/* obsolete */
+	{ CTDB_CAP_NATGW, "NATGW" },		/* obsolete */
+	{ CTDB_CAP_PARALLEL_RECOVERY, "PARALLEL_RECOVERY" },
+	{ CTDB_CAP_FRAGMENTED_CONTROLS, "FRAGMENTED_CONTROLS" },
+};
+
+_Static_assert(
+	CTDB_CAP_LAST == CTDB_CAP_FRAGMENTED_CONTROLS,
+	"pyctdb CTDB cap flags table needs to be updated"
+);
+
+#endif /* PYCLIENT_TABLES_H */

--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -657,6 +657,20 @@ def build(bld):
                      install_path='${BINDIR}',
                      manpages='ctdb.1')
 
+    bld.SAMBA_PYTHON('pyctdb',
+                     source=[
+                         'pyclient/pyclient_client.c',
+                         'pyclient/pyclient_db.c',
+                         'pyclient/pyclient_db_batch.c',
+                         'pyclient/pyclient_db_iter.c',
+                         'pyclient/pyclient_error.c',
+                         'pyclient/pyclient_module.c',
+                     ],
+                     deps='''ctdb-client ctdb-protocol ctdb-protocol-util
+                             ctdb-util ctdb-system samba-util sys_rw
+                             samba-util ctdbd''',
+                     realname='pyctdb.so')
+
     bld.SAMBA_BINARY('ctdb_killtcp',
                      source='tools/ctdb_killtcp.c',
                      deps='''ctdb-protocol-util ctdb-util ctdb-system


### PR DESCRIPTION
This commit adds some basic python bindings for the ctdb client with basic status and db-related functionality (including ability to sync the ctdb database with a local tdb variant).