### PR TITLE
Fix handling for POSIX renames for Mac clients

### DIFF
--- a/source3/modules/vfs_fruit.c
+++ b/source3/modules/vfs_fruit.c
@@ -4481,6 +4481,29 @@ static NTSTATUS fruit_create_file(vfs_handle_struct *handle,
 		goto fail;
 	}
 
+	/*
+	 * For directory FSPs opened without fd-requiring access (e.g.
+	 * DELETE|READ_ATTR), open_directory() does not call reopen_from_fsp()
+	 * and therefore fruit_openat() is never invoked for the main FSP.
+	 * This means fsp_flags.posix_open stays false even though sub-entries
+	 * inside the directory do get posix_open=true via fruit_openat().
+	 *
+	 * file_find_subpath() requires *both* dir_fsp and the sub-entry to
+	 * have posix_open=true before skipping the sub-entry (commit
+	 * 6e662bf5781). Without this, an open sub-entry such as a
+	 * com.apple.TimeMachine.sync.* directory blocks the final
+	 * .incomplete -> .sparsebundle rename with STATUS_ACCESS_DENIED.
+	 *
+	 * Set posix_open here, before the early return for directories, so
+	 * that the main directory FSP carries the same flag as its children.
+	 */
+	if (fsp->fsp_flags.is_directory &&
+	    config->posix_opens &&
+	    global_fruit_config.nego_aapl)
+	{
+		fsp->fsp_flags.posix_open = true;
+	}
+
 	if (is_named_stream(smb_fname) || fsp->fsp_flags.is_directory) {
 		return status;
 	}

--- a/source3/smbd/smb2_reply.c
+++ b/source3/smbd/smb2_reply.c
@@ -1371,7 +1371,7 @@ NTSTATUS rename_internals_fsp(connection_struct *conn,
 				true : conn->case_preserve;
 	struct vfs_rename_how rhow = { .flags = 0, };
 
-	if (file_has_open_streams(fsp)) {
+	if (!fsp->fsp_flags.posix_open && file_has_open_streams(fsp)) {
 		return NT_STATUS_ACCESS_DENIED;
 	}
 


### PR DESCRIPTION
This commit fixes handling for POSIX renames from MacOS clients.  MacOS clients during time machine backups don't properly close all files inside the sparsebundle file before trying to rename the temporary sparsebundle. This is typically not problematic in the sense of leaking fds because the SMB connection is temporary (closing once the client completes operations); however, it does presuppose different rename semantics on the SMB server than normally provided by the SMB protocol. This mismatch here was fixed by upstream samba in a prior release, but regressed again in 4.23 due to changes related to SMB posix extensions.