### PR TITLE
Fix several issues in error handling vfs modules (#531)

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -821,7 +821,6 @@ static NTSTATUS ixnas_generate_special_dacl_sd(struct vfs_handle_struct *handle,
 	NTSTATUS status;
 	struct dom_sid sid_owner, sid_group;
 	size_t sd_size = 0;
-	struct security_ace *nt_ace_list = NULL;
 	struct security_acl *psa = NULL;
 	uint16_t controlflags = SEC_DESC_SELF_RELATIVE | SEC_DESC_DACL_PROTECTED | SEC_DESC_DACL_PRESENT;
 
@@ -1019,7 +1018,7 @@ static bool ixnas_process_smbacl(vfs_handle_struct *handle,
 	zfsacl_t zfsacl;
 	struct SMB4ACE_T *smbace = NULL;
 	bool has_inheritable = false;
-	bool ok;
+	bool ok = false;
 	struct ixnas_config_data *config = NULL;
 
 	SMB_VFS_HANDLE_GET_DATA(handle, config,
@@ -1036,7 +1035,6 @@ static bool ixnas_process_smbacl(vfs_handle_struct *handle,
 	for (smbace=smb_first_ace4(smbacl);
 	     smbace!=NULL;
 	     smbace = smb_next_ace4(smbace)) {
-		bool ok;
 		SMB_ACE4PROP_T *aceprop = smb_get_ace4(smbace);
 
 		ok = smbace2zfsentry(zfsacl, aceprop);
@@ -1103,7 +1101,6 @@ static NTSTATUS ixnas_fset_special_dacl(vfs_handle_struct *handle,
 	 */
 
 	zfsacl_t zfsacl;
-	struct SMB4ACE_T *smbace = NULL;
 	zfsacl_entry_t placeholder_entry = NULL;
 	bool ok;
 	zfsace_permset_t perms;
@@ -1400,8 +1397,6 @@ static bool set_acl_parameters(struct vfs_handle_struct *handle,
 {
 	int ret;
 	char *chkpath = NULL;
-	acl_t zacl;
-	int is_trivial = 0;
 
 	ret = access(handle->conn->connectpath, F_OK);
 	if (ret != 0 && errno == ENOENT) {
@@ -1435,6 +1430,7 @@ static bool set_acl_parameters(struct vfs_handle_struct *handle,
 	handle->conn->aclbrand = path_get_aclbrand(handle->conn->connectpath);
 	if (handle->conn->aclbrand != TRUENAS_ACL_BRAND_NFS4) {
 		DBG_ERR("Connectpath does not support NFSv4 ACLs. Disabling ZFS ACL handling.\n");
+		TALLOC_FREE(chkpath);
 		return false;
 	}
 	TALLOC_FREE(chkpath);
@@ -1483,6 +1479,7 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 	ok = set_acl_parameters(handle, config);
 	if (!ok) {
 		TALLOC_FREE(config);
+		SMB_VFS_NEXT_DISCONNECT(handle);
 		return -1;
 	}
 

--- a/source3/modules/vfs_tmprotect.c
+++ b/source3/modules/vfs_tmprotect.c
@@ -117,6 +117,11 @@ static bool prune_snapshots(vfs_handle_struct *handle,
 			DBG_INFO("Appending [%s] to list of snapshots "
 				 "to be deleted.\n", entry->name);
 			del_entry = talloc_zero(talloc_tos(), struct snapshot_entry);
+			if (del_entry == NULL) {
+				TALLOC_FREE(snapshots);
+				TALLOC_FREE(to_delete);
+				return false;
+			}
 			strlcpy(del_entry->name, entry->name,
 				sizeof(del_entry->name));
 			DLIST_ADD(to_delete->entries, del_entry);
@@ -228,7 +233,7 @@ static bool parse_history(const char *history_path, size_t *cntp, time_t *timest
 		time_t tm_int;
 
 		begin = strstr(line, "<date>");
-		if (begin == NULL || begin == line) {
+		if (begin == NULL) {
 			DBG_DEBUG("skipping line: %s\n", line);
 			continue;
 		}
@@ -237,7 +242,6 @@ static bool parse_history(const char *history_path, size_t *cntp, time_t *timest
 		if (end == NULL) {
 			DBG_ERR("%s: strptime() failed: %s\n",
 				begin, strerror(errno));
-			free(line);
 			success = false;
 			break;
 		}
@@ -257,7 +261,6 @@ static bool parse_history(const char *history_path, size_t *cntp, time_t *timest
 	}
 
 	*cntp = cnt;
-out:
 	free(line);
 	fclose(history);
 	return success;
@@ -419,7 +422,7 @@ static void tmprotect_disconnect(vfs_handle_struct *handle)
 	 * Refuse to take more frequent snapshots than that.
 	 */
 
-	if ((config->history_file == NULL) || (last_snap + 900 > curtime)) {
+	if (last_snap + 900 > curtime) {
 		DBG_INFO("Refusing to generate new snapshot on disconnect"
 			 "last snapshot is less than 15 minutes old\n");
 		return;
@@ -427,6 +430,10 @@ static void tmprotect_disconnect(vfs_handle_struct *handle)
 	snapshot_name = talloc_asprintf(talloc_tos(), "%s-%lu",
 					TMPROTECT_PREFIX,
 					curtime);
+	if (snapshot_name == NULL) {
+		DBG_ERR("talloc_asprintf() failed\n");
+		return;
+	}
 
 	ret = smb_zfs_snapshot(config->hdl, snapshot_name, false);
 	if (ret != 0) {
@@ -456,14 +463,14 @@ static int tmprotect_connect(struct vfs_handle_struct *handle,
 	if (!config) {
 		DBG_ERR("talloc_zero() failed\n");
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	config->filter = talloc_zero(config, struct snap_filter);
 	if (config->filter == NULL) {
 		DBG_ERR("talloc_zero() failed\n");
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	inclusions = lp_parm_string_list(SNUM(handle->conn),

--- a/source3/modules/vfs_truenas_audit.c
+++ b/source3/modules/vfs_truenas_audit.c
@@ -280,7 +280,7 @@ static bool tn_audit_backend_init(vfs_handle_struct *handle,
 	if (enumval == -1) {
 		DBG_ERR("value for %s:backend type unknown\n",
 			MODULE_NAME);
-		return -1;
+		return false;
 	}
 
 	switch ((enum tn_audit_backend)enumval) {
@@ -386,13 +386,11 @@ static int tn_audit_connect(vfs_handle_struct *handle,
 	 *   "vers": {"major": 0, "minor": 1}
 	 * }
 	 */
-	int result, enumval;
+	int result;
 	tn_audit_conf_t *config = NULL;
 	struct json_object msg, entry, js_conn;
 	bool ok;
 	bool enabled;
-	const char **watch_list = NULL;
-	const char **ignore_list = NULL;
 
 	if (!conn_using_smb2(handle->conn->sconn)) {
 		DBG_ERR("%s: user connected to service [%s] via SMB1 protocol. "
@@ -410,13 +408,12 @@ static int tn_audit_connect(vfs_handle_struct *handle,
 	if (config == NULL) {
 		DBG_ERR("talloc_zero() failed\n");
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	ok = tn_audit_backend_init(handle, svc, user, config);
 	if (!ok) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	// If we fail to generate our connection info, then
@@ -425,35 +422,30 @@ static int tn_audit_connect(vfs_handle_struct *handle,
 	    &handle->conn->session_info->unique_session_token);
 
 	if (config->conn_info.sess == NULL) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	config->conn_info.user = talloc_strdup(config,
 	    handle->conn->session_info->unix_info->sanitized_username);
 	if (config->conn_info.user == NULL) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	js_conn = json_new_object();
 	if (json_is_invalid(&js_conn)) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	ok = tn_add_connection_info_to_obj(svc, handle->conn,
 					   &js_conn);
 	if (!ok) {
 		json_free(&js_conn);
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 	config->js_connection = json_to_string(config, &js_conn);
 	json_free(&js_conn);
 	if (config->js_connection == NULL) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 	SMB_VFS_HANDLE_SET_DATA(handle, config, NULL,
 				tn_audit_conf_t, return -1);
@@ -497,6 +489,11 @@ cleanup:
 	json_free(&entry);
 
 	return result;
+
+disconnect_out:
+	TALLOC_FREE(config);
+	SMB_VFS_NEXT_DISCONNECT(handle);
+	return -1;
 }
 
 static bool add_session_counters(tn_audit_conf_t *config,

--- a/source3/modules/vfs_truenas_audit_rw.c
+++ b/source3/modules/vfs_truenas_audit_rw.c
@@ -181,7 +181,6 @@ ssize_t tn_audit_pread(vfs_handle_struct *handle, files_struct *fsp,
 			      void *data, size_t n, off_t offset)
 {
 	ssize_t result;
-	bool ok;
 
 	result = SMB_VFS_NEXT_PREAD(handle, fsp, data, n, offset);
 
@@ -200,7 +199,6 @@ ssize_t tn_audit_pwrite(vfs_handle_struct *handle, files_struct *fsp,
 			       const void *data, size_t n, off_t offset)
 {
 	ssize_t result;
-	bool ok;
 
 	result = SMB_VFS_NEXT_PWRITE(handle, fsp, data, n, offset);
 

--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -102,8 +102,7 @@ static int zfs_core_get_quota(struct vfs_handle_struct *handle,
 	struct zfs_core_config_data *config = NULL;
 	struct zfs_dataset *ds = NULL;
 	struct zfs_quota zfs_qt;
-	uint64_t hardlimit, usedspace, xid;
-	hardlimit = usedspace = 0;
+	uint64_t hardlimit = 0, xid;
 
 	SMB_VFS_HANDLE_GET_DATA(handle, config,
 				struct zfs_core_config_data,
@@ -262,7 +261,7 @@ static bool get_synthetic_fsp(vfs_handle_struct *handle,
 	fd = open(fname_in, O_DIRECTORY, unix_mode);
 	if (fd == -1) {
 		DBG_ERR("Failed to open %s, mode: 0o%o: %s\n",
-			smb_fname_str_dbg(tmp_fname), unix_mode,
+			fname_in, unix_mode,
 			strerror(errno));
 		file_free(NULL, tmp_fsp);
 		return false;
@@ -279,7 +278,6 @@ static bool get_synthetic_fsp(vfs_handle_struct *handle,
 static bool zfs_inherit_acls(vfs_handle_struct *handle,
 			     struct zfs_core_config_data *config)
 {
-	struct zfs_dataset *ds = NULL;
 	size_t root_len;
 	struct stat st;
 	int error;
@@ -311,10 +309,12 @@ static bool zfs_inherit_acls(vfs_handle_struct *handle,
 	}
 
 	while (idx > 0) {
-		idx--;
-		ds = config->created[idx];
+		struct zfs_dataset *ds = NULL;
 		struct files_struct *c_fsp = NULL;
 		NTSTATUS status;
+
+		idx--;
+		ds = config->created[idx];
 
 		ok = get_synthetic_fsp(handle, ds->mountpoint + root_len, &c_fsp);
 		if (!ok) {
@@ -628,7 +628,6 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 {
 	struct zfs_core_config_data *config = NULL;
 	int ret;
-	const char *dataset_auto_quota = NULL;
 	const char *base_quota_str = NULL;
 
 	ret = SMB_VFS_NEXT_CONNECT(handle, service, user);
@@ -640,7 +639,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 	if (!config) {
 		DEBUG(0, ("talloc_zero() failed\n"));
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	/*
@@ -656,7 +655,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 	if (config->zfs_auto_create) {
 		ret = create_zfs_connectpath(handle, config, user);
 		if (ret < 0) {
-			return -1;
+			goto disconnect_out;
 		}
 	}
 
@@ -667,7 +666,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 	if (ret != 0) {
 		DBG_ERR("Failed to initialize ZFS data: %s\n",
 			strerror(errno));
-		return ret;
+		goto disconnect_out;
 	}
 
 	// We need to initialize the optable regardless of whether this
@@ -706,6 +705,11 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 				return -1);
 
 	return 0;
+
+disconnect_out:
+	TALLOC_FREE(config);
+	SMB_VFS_NEXT_DISCONNECT(handle);
+	return -1;
 }
 
 static struct vfs_fn_pointers zfs_core_fns = {


### PR DESCRIPTION
The associated changeset fixes several issues across truenas-specific VFS modules related to error handling.

1. design change for failure in samba VFS connect() functions (called by smbd when client first connecting to share). Originally we simply errored out without stepping through VFS disconnect functions. This commit adds a more explicit step to ensure that any required state is cleanly freed if we fail in connect functions. The change is not strictly required (most VFS modules do not have this handling), but its potentially cleaner and may avoid some edge-case resource leaks for the smbd session.

2. Fixes a potential UAF in automatic dataset creation if an error is encountered at a critical point.

3. Adds extra NULL checks for memory allocations in various modules in error paths.

4. Cleans up now-unused variables after removing FreeBSD-specific code.

5. Fixes case where potentially malformed snapshot history plist can cause auto-snapshot to be skipped.