### PR TITLE
NAS-140631 / Add RESOLVE_NO_XDEV handling

### DIFF
--- a/source3/include/vfs.h
+++ b/source3/include/vfs.h
@@ -712,6 +712,7 @@ typedef struct files_struct {
 #define TCON_FLAG_STREAMS_FILE		0x04
 #define TCON_FLAG_CASE_INSENSTIVE_FS	0x08
 #define TCON_FLAG_TRUENAS_ABE		0x10
+#define TCON_FLAG_NOXDEV		0x20
 
 struct vuid_cache_entry {
 	struct auth_session_info *session_info;
@@ -945,6 +946,7 @@ struct vfs_aio_state {
 #define VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS 1
 #define VFS_OPEN_HOW_WITH_BACKUP_INTENT 2
 #define VFS_OPEN_HOW_TRUENAS_ABE 4
+#define VFS_OPEN_HOW_RESOLVE_NO_XDEV 8
 
 struct vfs_open_how {
 	int flags;

--- a/source3/modules/vfs_default.c
+++ b/source3/modules/vfs_default.c
@@ -620,7 +620,8 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 
 	if (how->resolve & ~(VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS |
 			     VFS_OPEN_HOW_WITH_BACKUP_INTENT |
-			     VFS_OPEN_HOW_TRUENAS_ABE)) {
+			     VFS_OPEN_HOW_TRUENAS_ABE |
+			     VFS_OPEN_HOW_RESOLVE_NO_XDEV)) {
 		errno = ENOSYS;
 		result = -1;
 		goto out;
@@ -655,12 +656,20 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 	}
 #endif
 
-	if (how->resolve & VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS) {
+	if (how->resolve & (VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS |
+			    VFS_OPEN_HOW_RESOLVE_NO_XDEV)) {
 		struct open_how linux_how = {
 			.flags = flags,
 			.mode = mode,
-			.resolve = RESOLVE_NO_SYMLINKS,
+			.resolve = 0,
 		};
+
+		if (how->resolve & VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS) {
+			linux_how.resolve |= RESOLVE_NO_SYMLINKS;
+		}
+		if (how->resolve & VFS_OPEN_HOW_RESOLVE_NO_XDEV) {
+			linux_how.resolve |= RESOLVE_NO_XDEV;
+		}
 
 		result = openat2(dirfd,
 				 smb_fname->base_name,
@@ -669,14 +678,13 @@ static int vfswrap_openat(vfs_handle_struct *handle,
 		if (result == -1) {
 			if (errno == ENOSYS) {
 				/*
-				 * The kernel doesn't support
-				 * openat2(), so indicate to
-				 * the callers that
-				 * VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS
+				 * The kernel doesn't support openat2(), so
+				 * indicate to callers that these resolve flags
 				 * would just be a waste of time.
 				 */
 				fsp->conn->open_how_resolve &=
-					~VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS;
+					~(VFS_OPEN_HOW_RESOLVE_NO_SYMLINKS |
+					  VFS_OPEN_HOW_RESOLVE_NO_XDEV);
 			}
 			goto out;
 		}

--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -1066,6 +1066,15 @@ static int shadow_copy_zfs_open(vfs_handle_struct *handle,
 						   smb_fname_in,
 						   fsp, how);
 		}
+
+		/*
+		 * If we're here it means that we've configured the
+		 * share to not allow traversal out of dataset boundaries.
+		 * This means that if we are sharing dozer/SHARE and have
+		 * dozer/SHARE/SUBDATASET, we will not allow opening the
+		 * SUBDATASET. This is related to SMB share contract for
+		 * tiering more than anything else.
+		 */
 		noxdev_how = *how;
 		noxdev_how.resolve |= VFS_OPEN_HOW_RESOLVE_NO_XDEV;
 		return SMB_VFS_NEXT_OPENAT(handle,

--- a/source3/modules/vfs_shadow_copy_zfs.c
+++ b/source3/modules/vfs_shadow_copy_zfs.c
@@ -86,6 +86,7 @@ struct shadow_copy_zfs_config {
 	struct memcache		*zcache;
 
 	int			timedelta;
+	bool			no_dataset_traversal;
 	/* Snapshot parameters */
 	struct snap_filter	*filter;
 	struct snapshot_list 	*snapshots;
@@ -1043,6 +1044,10 @@ static int shadow_copy_zfs_open(vfs_handle_struct *handle,
 	struct snapshot_data data;
 	shadow_fsp_ext_t *fsp_ext = NULL;
 	struct vfs_open_how tmp_how = { .flags = how->flags, .mode = how->mode};
+	struct vfs_open_how noxdev_how;
+
+	SMB_VFS_HANDLE_GET_DATA(handle, config, struct shadow_copy_zfs_config,
+				return -1);
 
 	smb_fname = full_path_from_dirfsp_atname(talloc_tos(),
 						 dirfsp,
@@ -1050,14 +1055,24 @@ static int shadow_copy_zfs_open(vfs_handle_struct *handle,
 
 	if (!shadow_copy_zfs_match_name(handle, smb_fname)) {
 		TALLOC_FREE(smb_fname);
+		if (!config->no_dataset_traversal ||
+		    is_named_stream(smb_fname_in) ||
+		    ISDOT(smb_fname_in->base_name) ||
+		    strncmp(smb_fname_in->base_name,
+			    "/proc/self/fd/",
+			    sizeof("/proc/self/fd/") - 1) == 0) {
+			return SMB_VFS_NEXT_OPENAT(handle,
+						   dirfsp,
+						   smb_fname_in,
+						   fsp, how);
+		}
+		noxdev_how = *how;
+		noxdev_how.resolve |= VFS_OPEN_HOW_RESOLVE_NO_XDEV;
 		return SMB_VFS_NEXT_OPENAT(handle,
 					   dirfsp,
 					   smb_fname_in,
-					   fsp, how);
+					   fsp, &noxdev_how);
 	}
-
-	SMB_VFS_HANDLE_GET_DATA(handle, config, struct shadow_copy_zfs_config,
-				return -1);
 	/*
 	 * If dirfsp is an open in a snapshot directory, then concatenate the
 	 * dirfsp path with smb_fname relative path, convert into an absolute
@@ -1703,6 +1718,12 @@ static int shadow_copy_zfs_connect(struct vfs_handle_struct *handle,
 
 	config->filter->ignore_empty_snaps = lp_parm_bool(SNUM(handle->conn), "shadow",
 						"ignore_empty_snaps", true);
+
+	config->no_dataset_traversal = lp_parm_bool(SNUM(handle->conn), "shadow",
+						     "no_dataset_traversal", false);
+	if (config->no_dataset_traversal) {
+		handle->conn->internal_tcon_flags |= TCON_FLAG_NOXDEV;
+	}
 
 	config->timedelta = lp_parm_int(SNUM(handle->conn),
 					"shadow", "snap_timedelta", 30);

--- a/source3/smbd/dir.c
+++ b/source3/smbd/dir.c
@@ -626,6 +626,22 @@ bool smbd_dirptr_get_entry(TALLOC_CTX *ctx,
 			continue;
 		}
 
+		/*
+		 * If Share is configured not to step into child datasets,
+		 * prevent their mountpoints from appearing in directory listings
+		 * as well. NOTE that actual prevention of traversal is handled
+		 * by RESOLVE_NO_XDEV flag in openat2. This part is merely
+		 * cosmetic
+		 */
+		if (conn->internal_tcon_flags & TCON_FLAG_NOXDEV) {
+			if (smb_fname->st.st_ex_dev != dir_fname->st.st_ex_dev) {
+				TALLOC_FREE(smb_fname);
+				TALLOC_FREE(fname);
+				TALLOC_FREE(dname);
+				continue;
+			}
+		}
+
 		if (!S_ISLNK(smb_fname->st.st_ex_mode)) {
 			goto done;
 		}


### PR DESCRIPTION
This commit adds a non-default configurable option to vfs_shadow_copy_zfs to disable dataset traversal by setting the RESOLVE_NO_XDEV openat2 resolve flag for paths that are not snapdir-related. The business logic for determining whether to set this is inside the shadow copy module because that's the place where we determine whether a path is a snapshot. In the future we can probably consolidate into vfs_zfs_core module.