### PR TITLE
Add MIT kerberos runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,8 @@ Package: truenas-samba
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~), ${misc:Pre-Depends}
 Depends: adduser,
+         krb5-pkinit,                                                                                                                                                                                                               
+         libkrb5-3,       
          libpam-modules,
          libpam-runtime (>= 1.0.1-11),
          lsb-base (>= 4.1+Debian),


### PR DESCRIPTION
This commit adds MIT kerberos properly as a runtime dependency for the samba library.