### PR TITLE
NAS-140749 / mdssvc: close fsps before tearing down fake connections

### DIFF
--- a/source3/rpc_server/mdssvc/mdssvc.c
+++ b/source3/rpc_server/mdssvc/mdssvc.c
@@ -1640,6 +1640,13 @@ static int mds_ctx_destructor_cb(struct mds_ctx *mds_ctx)
 	TALLOC_FREE(mds_ctx->ino_path_map);
 
 	if (mds_ctx->conn != NULL) {
+		/*
+		 * VFS modules may hold conn-scoped pathref fsps whose fds
+		 * are not closed by talloc alone. Match close_cnum() ordering:
+		 * close the fsps first, then run the VFS disconnect hooks,
+		 * then free the conn.
+		 */
+		file_close_conn(mds_ctx->conn, SHUTDOWN_CLOSE);
 		SMB_VFS_DISCONNECT(mds_ctx->conn);
 		conn_free(mds_ctx->conn);
 	}

--- a/source3/smbd/msdfs.c
+++ b/source3/smbd/msdfs.c
@@ -320,6 +320,12 @@ static int conn_struct_tos_destructor(struct conn_struct_tos *c)
 		vfs_ChDir(c->conn, c->oldcwd_fname);
 		TALLOC_FREE(c->oldcwd_fname);
 	}
+	/*
+	 * VFS modules may hold conn-scoped pathref fsps whose fds are not
+	 * closed by talloc alone. Match close_cnum() ordering before freeing
+	 * the conn.
+	 */
+	file_close_conn(c->conn, SHUTDOWN_CLOSE);
 	SMB_VFS_DISCONNECT(c->conn);
 	conn_free(c->conn);
 	return 0;


### PR DESCRIPTION
TrueNAS is designed to create per-dataset recyclebins due to the way end-users sometimes nest datasets inside SMB shares. The default samba vfs_recycle actually silently deletes files when it hits mountpoint boundaries (rename fails). This was a workaround for a common anti-pattern in our community userbase and unfortunately cannot safely be removed until we announce full removal of recycle bin support. Due to changes in samba VFS design vfs_recycle on truenas keeps per-dataset recycle bin opens so that recycle ops are symlink race resistant. Unfortunately, the teardown for these bins is sensitive to the normal way that samba closes and frees shares. Basically, we expect the procedure to be:

1. close files opened under share
2. go through vfs_disconnect (to free up any internal vfs module resources)
3. free the share connection itself.

A couple of features relying on fake share connections don't properly implement all those steps (skipping 1) and instead relied on implicit talloc destructor ordering to handle cleanup.

The design of vfs_recycle breaks this assumption regarding destructor ordering, and so we could hit an SMB_ASSERT that the internally referenced opens were not properly closed. The associated commit ensures that the expected ordering of operations is maintained in the mds svc and in msdfs handling.