### PR TITLE
winbindd: silence null sid warning messages (#549)

### DIFF
--- a/source3/winbindd/winbindd_getgrnam.c
+++ b/source3/winbindd/winbindd_getgrnam.c
@@ -289,10 +289,12 @@ NTSTATUS winbindd_getgrnam_recv(struct tevent_req *req,
 	char *buf;
 
 	if (tevent_req_is_nterror(req, &status)) {
-		struct dom_sid_buf sidbuf;
-		D_WARNING("Could not convert sid %s: %s\n",
-			  dom_sid_str_buf(&state->sid, &sidbuf),
-			  nt_errstr(status));
+		if (!is_null_sid(&state->sid)) {
+			struct dom_sid_buf sidbuf;
+			D_WARNING("Could not convert sid %s: %s\n",
+				  dom_sid_str_buf(&state->sid, &sidbuf),
+				  nt_errstr(status));
+		}
 		return status;
 	}
 

--- a/source3/winbindd/winbindd_getpwnam.c
+++ b/source3/winbindd/winbindd_getpwnam.c
@@ -196,10 +196,12 @@ NTSTATUS winbindd_getpwnam_recv(struct tevent_req *req,
 	NTSTATUS status;
 
 	if (tevent_req_is_nterror(req, &status)) {
-		struct dom_sid_buf buf;
-		D_WARNING("Could not convert sid %s: %s\n",
-			  dom_sid_str_buf(&state->sid, &buf),
-			  nt_errstr(status));
+		if (!is_null_sid(&state->sid)) {
+			struct dom_sid_buf buf;
+			D_WARNING("Could not convert sid %s: %s\n",
+				  dom_sid_str_buf(&state->sid, &buf),
+				  nt_errstr(status));
+		}
 		return status;
 	}
 	response->data.pw = state->pw;


### PR DESCRIPTION
This commit drops a warning message about null sid failing to resolve on error paths related to user and group lookups by name from WARNING (shows all the time) to INFO (only shows at elevated log levels.