### PR TITLE
Cherry-pick in vfs_tmprotect fixes from stable/26

### DIFF
--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -821,7 +821,6 @@ static NTSTATUS ixnas_generate_special_dacl_sd(struct vfs_handle_struct *handle,
 	NTSTATUS status;
 	struct dom_sid sid_owner, sid_group;
 	size_t sd_size = 0;
-	struct security_ace *nt_ace_list = NULL;
 	struct security_acl *psa = NULL;
 	uint16_t controlflags = SEC_DESC_SELF_RELATIVE | SEC_DESC_DACL_PROTECTED | SEC_DESC_DACL_PRESENT;
 
@@ -1019,7 +1018,7 @@ static bool ixnas_process_smbacl(vfs_handle_struct *handle,
 	zfsacl_t zfsacl;
 	struct SMB4ACE_T *smbace = NULL;
 	bool has_inheritable = false;
-	bool ok;
+	bool ok = false;
 	struct ixnas_config_data *config = NULL;
 
 	SMB_VFS_HANDLE_GET_DATA(handle, config,
@@ -1036,7 +1035,6 @@ static bool ixnas_process_smbacl(vfs_handle_struct *handle,
 	for (smbace=smb_first_ace4(smbacl);
 	     smbace!=NULL;
 	     smbace = smb_next_ace4(smbace)) {
-		bool ok;
 		SMB_ACE4PROP_T *aceprop = smb_get_ace4(smbace);
 
 		ok = smbace2zfsentry(zfsacl, aceprop);
@@ -1103,7 +1101,6 @@ static NTSTATUS ixnas_fset_special_dacl(vfs_handle_struct *handle,
 	 */
 
 	zfsacl_t zfsacl;
-	struct SMB4ACE_T *smbace = NULL;
 	zfsacl_entry_t placeholder_entry = NULL;
 	bool ok;
 	zfsace_permset_t perms;
@@ -1400,8 +1397,6 @@ static bool set_acl_parameters(struct vfs_handle_struct *handle,
 {
 	int ret;
 	char *chkpath = NULL;
-	acl_t zacl;
-	int is_trivial = 0;
 
 	ret = access(handle->conn->connectpath, F_OK);
 	if (ret != 0 && errno == ENOENT) {
@@ -1435,6 +1430,7 @@ static bool set_acl_parameters(struct vfs_handle_struct *handle,
 	handle->conn->aclbrand = path_get_aclbrand(handle->conn->connectpath);
 	if (handle->conn->aclbrand != TRUENAS_ACL_BRAND_NFS4) {
 		DBG_ERR("Connectpath does not support NFSv4 ACLs. Disabling ZFS ACL handling.\n");
+		TALLOC_FREE(chkpath);
 		return false;
 	}
 	TALLOC_FREE(chkpath);
@@ -1483,6 +1479,7 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 	ok = set_acl_parameters(handle, config);
 	if (!ok) {
 		TALLOC_FREE(config);
+		SMB_VFS_NEXT_DISCONNECT(handle);
 		return -1;
 	}
 

--- a/source3/modules/vfs_tmprotect.c
+++ b/source3/modules/vfs_tmprotect.c
@@ -41,11 +41,14 @@ struct tmprotect_config_data {
 	struct snap_filter *filter;
 	int retention;
 	int min_snaps;
+	int deferred_seconds;
 	bool enabled;
 	char *history_file;
 	time_t last_snap;
 	time_t oldest_snap;
 	time_t last_success;
+	size_t last_count;
+	struct tevent_timer *pending_snap;
 };
 
 static bool init_zfs(vfs_handle_struct *handle,
@@ -344,6 +347,7 @@ static int tmprotect_openat(vfs_handle_struct *handle,
 	ok = parse_history(config->history_file, &cnt, &last_success);
 	if (ok && cnt) {
 		config->last_success = last_success;
+		config->last_count = cnt;
 	}
 
 	ok = prune_snapshots(handle, config);
@@ -381,19 +385,185 @@ static bool history_changed(vfs_handle_struct *handle,
 	return rv;
 }
 
-static void tmprotect_disconnect(vfs_handle_struct *handle)
+static void tmprotect_take_snapshot(vfs_handle_struct *handle,
+				    struct tmprotect_config_data *config)
 {
 	int ret;
 	bool ok;
 	time_t curtime, last_snap;
-	struct tmprotect_config_data *config = NULL;
 	char *snapshot_name = NULL;
 
 	time(&curtime);
+
+	ok = last_snap_ts(handle, config, &last_snap);
+	if (!ok) {
+		DBG_ERR("Failed to look up timestamp for last snapshot\n");
+		return;
+	}
+
+	/*
+	 * Time machine will back up once every 15 minutes by default.
+	 * Refuse to take more frequent snapshots than that.
+	 */
+
+	if (last_snap + 900 > curtime) {
+		DBG_INFO("Refusing to generate new snapshot: "
+			 "last snapshot is less than 15 minutes old\n");
+		return;
+	}
+
+	snapshot_name = talloc_asprintf(talloc_tos(), "%s-%lu",
+					TMPROTECT_PREFIX,
+					curtime);
+	if (snapshot_name == NULL) {
+		DBG_ERR("talloc_asprintf() failed\n");
+		return;
+	}
+
+	ret = smb_zfs_snapshot(config->hdl, snapshot_name, false);
+	if (ret != 0) {
+		DBG_ERR("Failed to generate snapshot on path: %s\n",
+			handle->conn->connectpath);
+		TALLOC_FREE(snapshot_name);
+		return;
+	}
+
+	DBG_INFO("%s: snapshot taken following successful time machine backup\n",
+		 snapshot_name);
+	TALLOC_FREE(snapshot_name);
+}
+
+static void tmprotect_deferred_snapshot(struct tevent_context *ev,
+					struct tevent_timer *te,
+					struct timeval current_time,
+					void *private_data)
+{
+	struct vfs_handle_struct *handle =
+		(struct vfs_handle_struct *)private_data;
+	struct tmprotect_config_data *config = NULL;
+
 	SMB_VFS_HANDLE_GET_DATA(handle,
 				config,
 				struct tmprotect_config_data,
-				NULL);
+				return);
+
+	/*
+	 * tevent callbacks fire with whatever security context happens to be
+	 * current — typically the last impersonated SMB user. libzfs needs
+	 * root, so drop user impersonation explicitly. Matches the pattern in
+	 * housekeeping_fn / smbd_sig_hup_handler / smbd_conf_updated.
+	 */
+	change_to_root_user();
+
+	/*
+	 * Clear the pointer before tevent destroys `te` after this callback
+	 * returns, so the disconnect path can distinguish "snapshot pending"
+	 * from "snapshot already taken".
+	 */
+	config->pending_snap = NULL;
+
+	tmprotect_take_snapshot(handle, config);
+}
+
+static int tmprotect_renameat(vfs_handle_struct *handle,
+			      files_struct *srcfsp,
+			      const struct smb_filename *smb_fname_src,
+			      files_struct *dstfsp,
+			      const struct smb_filename *smb_fname_dst,
+			      const struct vfs_rename_how *how)
+{
+	int ret;
+	struct tmprotect_config_data *config = NULL;
+	size_t cnt = 0, dlen, slen = strlen(tm_plist_suffix);
+	time_t timestamp = 0;
+	bool parse_ok, has_new_backup = false;
+	struct tevent_timer *new_te = NULL;
+
+	ret = SMB_VFS_NEXT_RENAMEAT(handle, srcfsp, smb_fname_src,
+				    dstfsp, smb_fname_dst, how);
+	if (ret != 0) {
+		return ret;
+	}
+
+	SMB_VFS_HANDLE_GET_DATA(handle,
+				config,
+				struct tmprotect_config_data,
+				return ret);
+
+	if (!config->enabled || config->history_file == NULL) {
+		return ret;
+	}
+
+	dlen = strlen(smb_fname_dst->base_name);
+	if ((dlen < slen) ||
+	    (strcmp(tm_plist_suffix,
+		    smb_fname_dst->base_name + (dlen - slen)) != 0)) {
+		return ret;
+	}
+
+	parse_ok = parse_history(config->history_file, &cnt, &timestamp);
+	if (parse_ok && cnt > 0 &&
+	    (cnt > config->last_count || timestamp > config->last_success)) {
+		has_new_backup = true;
+	}
+
+	/*
+	 * Reset the timer on every rename targeting the plist, even when the
+	 * count didn't change: macOS issues a thundering herd of renames on
+	 * backup completion, and the snapshot should fire only once those
+	 * renames have stopped for deferred_seconds.
+	 */
+	if (!has_new_backup && config->pending_snap == NULL) {
+		return ret;
+	}
+
+	new_te = tevent_add_timer(handle->conn->sconn->ev_ctx,
+				  config,
+				  tevent_timeval_current_ofs(config->deferred_seconds, 0),
+				  tmprotect_deferred_snapshot,
+				  handle);
+	if (new_te == NULL) {
+		DBG_ERR("tevent_add_timer() failed; deferred snapshot not "
+			"scheduled, falling back to disconnect-time path\n");
+		return ret;
+	}
+
+	/*
+	 * Free the old timer only after the new one was successfully armed.
+	 * If tevent_add_timer() had failed we'd have returned above with the
+	 * old timer still armed, rather than cancelling it and ending up with
+	 * no scheduled snapshot at all.
+	 */
+	TALLOC_FREE(config->pending_snap);
+	config->pending_snap = new_te;
+
+	/*
+	 * Only commit tracking updates after a timer was successfully armed.
+	 * Updating earlier would make history_changed() return false even
+	 * when no snapshot is pending, losing the disconnect-time fallback.
+	 */
+	if (has_new_backup) {
+		config->last_count = cnt;
+		config->last_success = timestamp;
+		DBG_INFO("Scheduled deferred Time Machine snapshot in %d "
+			 "seconds (plist count=%zu, timestamp=%ld)\n",
+			 config->deferred_seconds, cnt, timestamp);
+	} else {
+		DBG_INFO("Rearmed deferred Time Machine snapshot timer "
+			 "(%d seconds from now)\n", config->deferred_seconds);
+	}
+
+	return ret;
+}
+
+static void tmprotect_disconnect(vfs_handle_struct *handle)
+{
+	struct tmprotect_config_data *config = NULL;
+
+	SMB_VFS_HANDLE_GET_DATA(handle,
+				config,
+				struct tmprotect_config_data,
+				return);
 
 	/*
 	 * This SMB session may not have been a time machine backup.
@@ -405,44 +575,30 @@ static void tmprotect_disconnect(vfs_handle_struct *handle)
 		return;
 	}
 
-	ok = history_changed(handle, config);
-	if (!ok) {
-		DBG_INFO("No changes recorded in snapshot history file\n");
-		return;
-	}
-
-	ok = last_snap_ts(handle, config, &last_snap);
-	if (!ok) {
-		DBG_ERR("Failed to look up timestamp for last session\n");
+	if (config->pending_snap != NULL) {
+		/*
+		 * The rename hook scheduled a deferred snapshot but the
+		 * client is disconnecting before the timer fires. Take the
+		 * snapshot now and cancel the pending timer.
+		 */
+		DBG_INFO("Disconnecting with deferred snapshot pending; "
+			 "taking snapshot inline\n");
+		TALLOC_FREE(config->pending_snap);
+		tmprotect_take_snapshot(handle, config);
 		return;
 	}
 
 	/*
-	 * Time machine will back up once every 15 minutes by default.
-	 * Refuse to take more frequent snapshots than that.
+	 * Fallback for clients that update the plist in place rather than
+	 * via atomic rename — the rename hook never fired so check the plist
+	 * directly.
 	 */
-
-	if (last_snap + 900 > curtime) {
-		DBG_INFO("Refusing to generate new snapshot on disconnect"
-			 "last snapshot is less than 15 minutes old\n");
-		return;
-	}
-	snapshot_name = talloc_asprintf(talloc_tos(), "%s-%lu",
-					TMPROTECT_PREFIX,
-					curtime);
-	if (snapshot_name == NULL) {
-		DBG_ERR("talloc_asprintf() failed\n");
+	if (!history_changed(handle, config)) {
+		DBG_INFO("No changes recorded in snapshot history file\n");
 		return;
 	}
 
-	ret = smb_zfs_snapshot(config->hdl, snapshot_name, false);
-	if (ret != 0) {
-		DBG_ERR("Failed to generate closing snapshot on path: %s\n",
-			handle->conn->connectpath);
-	}
-
-	DBG_INFO("%s: snapshot taken following successful time machine backup\n",
-		 snapshot_name);
+	tmprotect_take_snapshot(handle, config);
 }
 
 
@@ -506,6 +662,13 @@ static int tmprotect_connect(struct vfs_handle_struct *handle,
 					TMPROTECT_MODULE,
 					"min_snaps", 3);
 
+	config->deferred_seconds = lp_parm_int(SNUM(handle->conn),
+					       TMPROTECT_MODULE,
+					       "deferred_seconds", 60);
+	if (config->deferred_seconds < 1) {
+		config->deferred_seconds = 60;
+	}
+
 	SMB_VFS_HANDLE_SET_DATA(handle, config,
 				NULL, struct tmprotect_config_data,
 				return -1);
@@ -524,6 +687,7 @@ static struct vfs_fn_pointers tmprotect_fns = {
 	.disconnect_fn = tmprotect_disconnect,
 	.connect_fn = tmprotect_connect,
 	.openat_fn = tmprotect_openat,
+	.renameat_fn = tmprotect_renameat,
 };
 
 NTSTATUS vfs_tmprotect_init(TALLOC_CTX *);

--- a/source3/modules/vfs_tmprotect.c
+++ b/source3/modules/vfs_tmprotect.c
@@ -117,6 +117,11 @@ static bool prune_snapshots(vfs_handle_struct *handle,
 			DBG_INFO("Appending [%s] to list of snapshots "
 				 "to be deleted.\n", entry->name);
 			del_entry = talloc_zero(talloc_tos(), struct snapshot_entry);
+			if (del_entry == NULL) {
+				TALLOC_FREE(snapshots);
+				TALLOC_FREE(to_delete);
+				return false;
+			}
 			strlcpy(del_entry->name, entry->name,
 				sizeof(del_entry->name));
 			DLIST_ADD(to_delete->entries, del_entry);
@@ -228,7 +233,7 @@ static bool parse_history(const char *history_path, size_t *cntp, time_t *timest
 		time_t tm_int;
 
 		begin = strstr(line, "<date>");
-		if (begin == NULL || begin == line) {
+		if (begin == NULL) {
 			DBG_DEBUG("skipping line: %s\n", line);
 			continue;
 		}
@@ -237,7 +242,6 @@ static bool parse_history(const char *history_path, size_t *cntp, time_t *timest
 		if (end == NULL) {
 			DBG_ERR("%s: strptime() failed: %s\n",
 				begin, strerror(errno));
-			free(line);
 			success = false;
 			break;
 		}
@@ -257,7 +261,6 @@ static bool parse_history(const char *history_path, size_t *cntp, time_t *timest
 	}
 
 	*cntp = cnt;
-out:
 	free(line);
 	fclose(history);
 	return success;
@@ -419,7 +422,7 @@ static void tmprotect_disconnect(vfs_handle_struct *handle)
 	 * Refuse to take more frequent snapshots than that.
 	 */
 
-	if ((config->history_file == NULL) || (last_snap + 900 > curtime)) {
+	if (last_snap + 900 > curtime) {
 		DBG_INFO("Refusing to generate new snapshot on disconnect"
 			 "last snapshot is less than 15 minutes old\n");
 		return;
@@ -427,6 +430,10 @@ static void tmprotect_disconnect(vfs_handle_struct *handle)
 	snapshot_name = talloc_asprintf(talloc_tos(), "%s-%lu",
 					TMPROTECT_PREFIX,
 					curtime);
+	if (snapshot_name == NULL) {
+		DBG_ERR("talloc_asprintf() failed\n");
+		return;
+	}
 
 	ret = smb_zfs_snapshot(config->hdl, snapshot_name, false);
 	if (ret != 0) {
@@ -456,14 +463,14 @@ static int tmprotect_connect(struct vfs_handle_struct *handle,
 	if (!config) {
 		DBG_ERR("talloc_zero() failed\n");
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	config->filter = talloc_zero(config, struct snap_filter);
 	if (config->filter == NULL) {
 		DBG_ERR("talloc_zero() failed\n");
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	inclusions = lp_parm_string_list(SNUM(handle->conn),

--- a/source3/modules/vfs_truenas_audit.c
+++ b/source3/modules/vfs_truenas_audit.c
@@ -280,7 +280,7 @@ static bool tn_audit_backend_init(vfs_handle_struct *handle,
 	if (enumval == -1) {
 		DBG_ERR("value for %s:backend type unknown\n",
 			MODULE_NAME);
-		return -1;
+		return false;
 	}
 
 	switch ((enum tn_audit_backend)enumval) {
@@ -386,13 +386,11 @@ static int tn_audit_connect(vfs_handle_struct *handle,
 	 *   "vers": {"major": 0, "minor": 1}
 	 * }
 	 */
-	int result, enumval;
+	int result;
 	tn_audit_conf_t *config = NULL;
 	struct json_object msg, entry, js_conn;
 	bool ok;
 	bool enabled;
-	const char **watch_list = NULL;
-	const char **ignore_list = NULL;
 
 	if (!conn_using_smb2(handle->conn->sconn)) {
 		DBG_ERR("%s: user connected to service [%s] via SMB1 protocol. "
@@ -410,13 +408,12 @@ static int tn_audit_connect(vfs_handle_struct *handle,
 	if (config == NULL) {
 		DBG_ERR("talloc_zero() failed\n");
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	ok = tn_audit_backend_init(handle, svc, user, config);
 	if (!ok) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	// If we fail to generate our connection info, then
@@ -425,35 +422,30 @@ static int tn_audit_connect(vfs_handle_struct *handle,
 	    &handle->conn->session_info->unique_session_token);
 
 	if (config->conn_info.sess == NULL) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	config->conn_info.user = talloc_strdup(config,
 	    handle->conn->session_info->unix_info->sanitized_username);
 	if (config->conn_info.user == NULL) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	js_conn = json_new_object();
 	if (json_is_invalid(&js_conn)) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 
 	ok = tn_add_connection_info_to_obj(svc, handle->conn,
 					   &js_conn);
 	if (!ok) {
 		json_free(&js_conn);
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 	config->js_connection = json_to_string(config, &js_conn);
 	json_free(&js_conn);
 	if (config->js_connection == NULL) {
-		TALLOC_FREE(config);
-		return -1;
+		goto disconnect_out;
 	}
 	SMB_VFS_HANDLE_SET_DATA(handle, config, NULL,
 				tn_audit_conf_t, return -1);
@@ -497,6 +489,11 @@ cleanup:
 	json_free(&entry);
 
 	return result;
+
+disconnect_out:
+	TALLOC_FREE(config);
+	SMB_VFS_NEXT_DISCONNECT(handle);
+	return -1;
 }
 
 static bool add_session_counters(tn_audit_conf_t *config,

--- a/source3/modules/vfs_truenas_audit_rw.c
+++ b/source3/modules/vfs_truenas_audit_rw.c
@@ -181,7 +181,6 @@ ssize_t tn_audit_pread(vfs_handle_struct *handle, files_struct *fsp,
 			      void *data, size_t n, off_t offset)
 {
 	ssize_t result;
-	bool ok;
 
 	result = SMB_VFS_NEXT_PREAD(handle, fsp, data, n, offset);
 
@@ -200,7 +199,6 @@ ssize_t tn_audit_pwrite(vfs_handle_struct *handle, files_struct *fsp,
 			       const void *data, size_t n, off_t offset)
 {
 	ssize_t result;
-	bool ok;
 
 	result = SMB_VFS_NEXT_PWRITE(handle, fsp, data, n, offset);
 

--- a/source3/modules/vfs_zfs_core.c
+++ b/source3/modules/vfs_zfs_core.c
@@ -102,8 +102,7 @@ static int zfs_core_get_quota(struct vfs_handle_struct *handle,
 	struct zfs_core_config_data *config = NULL;
 	struct zfs_dataset *ds = NULL;
 	struct zfs_quota zfs_qt;
-	uint64_t hardlimit, usedspace, xid;
-	hardlimit = usedspace = 0;
+	uint64_t hardlimit = 0, xid;
 
 	SMB_VFS_HANDLE_GET_DATA(handle, config,
 				struct zfs_core_config_data,
@@ -263,7 +262,7 @@ static bool get_synthetic_fsp(vfs_handle_struct *handle,
 	fd = open(fname_in, O_DIRECTORY, unix_mode);
 	if (fd == -1) {
 		DBG_ERR("Failed to open %s, mode: 0o%o: %s\n",
-			smb_fname_str_dbg(tmp_fname), unix_mode,
+			fname_in, unix_mode,
 			strerror(errno));
 		file_free(NULL, tmp_fsp);
 		return false;
@@ -280,7 +279,6 @@ static bool get_synthetic_fsp(vfs_handle_struct *handle,
 static bool zfs_inherit_acls(vfs_handle_struct *handle,
 			     struct zfs_core_config_data *config)
 {
-	struct zfs_dataset *ds = NULL;
 	size_t root_len;
 	struct stat st;
 	int error;
@@ -312,10 +310,12 @@ static bool zfs_inherit_acls(vfs_handle_struct *handle,
 	}
 
 	while (idx > 0) {
-		idx--;
-		ds = config->created[idx];
+		struct zfs_dataset *ds = NULL;
 		struct files_struct *c_fsp = NULL;
 		NTSTATUS status;
+
+		idx--;
+		ds = config->created[idx];
 
 		ok = get_synthetic_fsp(handle, ds->mountpoint + root_len, &c_fsp);
 		if (!ok) {
@@ -630,7 +630,6 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 {
 	struct zfs_core_config_data *config = NULL;
 	int ret;
-	const char *dataset_auto_quota = NULL;
 	const char *base_quota_str = NULL;
 
 	ret = SMB_VFS_NEXT_CONNECT(handle, service, user);
@@ -642,7 +641,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 	if (!config) {
 		DEBUG(0, ("talloc_zero() failed\n"));
 		errno = ENOMEM;
-		return -1;
+		goto disconnect_out;
 	}
 
 	/*
@@ -658,7 +657,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 	if (config->zfs_auto_create) {
 		ret = create_zfs_connectpath(handle, config, user);
 		if (ret < 0) {
-			return -1;
+			goto disconnect_out;
 		}
 	}
 
@@ -669,7 +668,7 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 	if (ret != 0) {
 		DBG_ERR("Failed to initialize ZFS data: %s\n",
 			strerror(errno));
-		return ret;
+		goto disconnect_out;
 	}
 
 	// We need to initialize the optable regardless of whether this
@@ -708,6 +707,11 @@ static int zfs_core_connect(struct vfs_handle_struct *handle,
 				return -1);
 
 	return 0;
+
+disconnect_out:
+	TALLOC_FREE(config);
+	SMB_VFS_NEXT_DISCONNECT(handle);
+	return -1;
 }
 
 static struct vfs_fn_pointers zfs_core_fns = {


### PR DESCRIPTION
This commit backports two significant fixes from the stable/26 branch:

* Some error handling for plist reads in vfs_tmprotect
* Improved handling for MacOS clients that keep persistent SMB session for time machine.