### PR TITLE
NAS-141608 / ixnas: advertise only the WRITE_ACL/WRITE_OWNER that ZFS honors

### DIFF
--- a/.github/workflows/scripts/qemu-4-test.sh
+++ b/.github/workflows/scripts/qemu-4-test.sh
@@ -330,6 +330,58 @@ if python3 -c "import os; os.getxattr('/tank/acl', 'system.nfs4_acl_xdr')" 2>/de
   else
     echo "ERROR: truenas.acl mapping suite FAILED"; tail -80 /var/log/samba4/smbd.log; exit 1
   fi
+
+  # ---- Advertisement-only proof: SMB demotes special identities, on-disk
+  # (NFS view) ACL is left untouched. ixnas strips WRITE_ACL/WRITE_OWNER from
+  # owner@/group@/everyone@ in the SD it reports because ZFS will not honor them
+  # there, while named entries keep them. truenas_setfacl lays down a fixture
+  # carrying both on disk; truenas.acl.fixture_scope checks the SMB view; and
+  # truenas_getfacl before/after proves the GET never rewrote the stored ACL.
+  # Best-effort: truenas_pyos builds a C extension (needs gcc + libbsd-dev), so
+  # skip without failing the run if it cannot be installed.
+  echo "--- ixnas demote: on-disk ACL untouched (truenas_pyos) ---"
+  # truenas_pyos builds a C extension and is pip-installed from git, so it needs
+  # pip + Python headers + libbsd-dev (gcc/git are already present from the
+  # ZFS/Samba build). Trixie ships no pip by default -- without python3-pip the
+  # install fails "No module named pip" and fixture_scope silently self-skips.
+  apt-get install -y --no-install-recommends \
+    python3-pip python3-dev libbsd-dev >/dev/null 2>&1 || true
+  if python3 -m pip install --break-system-packages --quiet \
+       "git+https://github.com/truenas/truenas_pyos" >/tmp/pyos-install.log 2>&1 \
+     && command -v truenas_setfacl >/dev/null 2>&1; then
+    assert_ondisk_owner_full() {
+      truenas_getfacl -j -n "$1" | python3 -c '
+import sys, json
+acl = json.loads(sys.stdin.read())
+o = next((set(e["perms"]) for e in acl["aces"] if e["who"] == "owner@"), None)
+assert o is not None, "no owner@ entry on disk"
+assert "WRITE_ACL" in o and "WRITE_OWNER" in o, \
+    "owner@ lacks WRITE_ACL/WRITE_OWNER on disk"
+'
+    }
+    FIX=/tank/acl/pyfix
+    : > "$FIX"; chown smbtest:smbtest "$FIX"
+    # owner@/group@/everyone@ + a named user (root) all Full Control, so the
+    # stored ACL carries WRITE_ACL(C)+WRITE_OWNER(o) on every entry.
+    truenas_setfacl -m 'owner@:full_set::allow,group@:full_set::allow,everyone@:full_set::allow,user:0:full_set::allow' "$FIX"
+    echo "on-disk ACL (before SMB GET):"; truenas_getfacl -n "$FIX" || true
+    assert_ondisk_owner_full "$FIX" \
+      || { echo "ERROR: fixture setup -- owner@ lacks WRITE_ACL/WRITE_OWNER on disk"; exit 1; }
+    if "$SMBTORTURE" //127.0.0.1/zacl -U 'smbtest%testpass123' \
+         --option='torture:acl_nfs4=yes' --option='torture:acl_fixture=pyfix' \
+         truenas.acl.fixture_scope; then
+      echo "truenas.acl.fixture_scope PASSED (SMB demotes special, keeps named)"
+    else
+      echo "ERROR: truenas.acl.fixture_scope FAILED"; tail -80 /var/log/samba4/smbd.log; exit 1
+    fi
+    assert_ondisk_owner_full "$FIX" \
+      || { echo "ERROR: SMB GET mutated the on-disk ACL (owner@ lost WRITE_ACL/WRITE_OWNER)"; exit 1; }
+    echo "on-disk ACL unchanged by SMB GET -- advertisement-only confirmed"
+    rm -f "$FIX"
+  else
+    echo "WARN: truenas_pyos unavailable; skipping on-disk advertisement-only check"
+    tail -3 /tmp/pyos-install.log 2>/dev/null || true
+  fi
 else
   echo "WARN: ZFS does not expose system.nfs4_acl_xdr on /tank/acl; skipping ACL suite"
 fi

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -32,6 +32,7 @@ static int vfs_ixnas_debug_level = DBGC_VFS;
 struct ixnas_config_data {
 	struct smbacl4_vfs_params nfs4_params;
 	bool dosattrib_xattr;
+	bool advertise_enforced_acl;
 };
 
 enum ixnas_dacl_type {
@@ -442,7 +443,8 @@ static int path_get_aclbrand(const char *path)
 }
 
 /* Convert the native ZFS ACE format to the generic Samba NFSv4 format */
-static bool zfsentry2smbace(zfsacl_entry_t ae, SMB_ACE4PROP_T *aceprop)
+static bool zfsentry2smbace(zfsacl_entry_t ae, SMB_ACE4PROP_T *aceprop,
+			    bool advertise_enforced)
 {
 	int i;
 	zfsace_permset_t perms = 0;
@@ -515,6 +517,21 @@ static bool zfsentry2smbace(zfsacl_entry_t ae, SMB_ACE4PROP_T *aceprop)
 	if ((aceprop->aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE) &&
 	    (aceprop->aceMask != 0)) {
 		aceprop->aceMask |= SMB_ACE4_SYNCHRONIZE;
+	}
+
+	/*
+	 * Advertisement-only: ZFS will not honor WRITE_ACL/WRITE_OWNER granted
+	 * through owner@/group@/everyone@, so do not report those bits on the
+	 * special identities. This drops them from the SD we present, never from
+	 * what we store (the set path is untouched), so SMB and NFS clients on the
+	 * same dataset keep getting identical, ZFS-enforced access. Named
+	 * user/group entries (flags == 0) still convey these rights and so are
+	 * left intact. Gated by ixnas:zfs_acl_advertise_enforced.
+	 */
+	if (advertise_enforced &&
+	    (aceprop->flags & SMB_ACE4_ID_SPECIAL) &&
+	    (aceprop->aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE)) {
+		aceprop->aceMask &= ~(SMB_ACE4_WRITE_ACL | SMB_ACE4_WRITE_OWNER);
 	}
 
 	return true;
@@ -713,7 +730,7 @@ static NTSTATUS ixnas_get_nt_acl_nfs4_common(struct connection_struct *conn,
 			return map_nt_error_from_unix(errno);
 		}
 
-		ok = zfsentry2smbace(ae, &aceprop);
+		ok = zfsentry2smbace(ae, &aceprop, config->advertise_enforced_acl);
 		if (!ok) {
 			TALLOC_FREE(pacl);
 			return map_nt_error_from_unix(errno);
@@ -1475,6 +1492,14 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 	if (!config->dosattrib_xattr) {
 		lp_do_parameter(SNUM(handle->conn), "kernel dosmodes", "yes");
 	}
+
+	/*
+	 * Present only the WRITE_ACL/WRITE_OWNER that ZFS will actually honor:
+	 * strip those bits from owner@/group@/everyone@ in the SD we report (not
+	 * from what we store). Default on; set to no to advertise the raw ACL.
+	 */
+	config->advertise_enforced_acl = lp_parm_bool(SNUM(handle->conn),
+			"ixnas", "zfs_acl_advertise_enforced", true);
 
 	ok = set_acl_parameters(handle, config);
 	if (!ok) {

--- a/source4/torture/truenas/truenas_acl.c
+++ b/source4/torture/truenas/truenas_acl.c
@@ -7,7 +7,7 @@
    (stored in the system.nfs4_acl_xdr xattr provided by the TrueNAS ZFS module)
    and the Windows Security Descriptor seen over SMB2. They assert mapping
    correctness only -- SET/GET of a security descriptor over the wire -- not the
-   kernel-enforced access-check edge cases (delete behaviour, access-based
+   kernel-enforced access-check edge cases (delete behavior, access-based
    enumeration) which depend on a TrueNAS-patched base kernel and so cannot be
    validated on a stock-kernel CI runner.
 
@@ -69,8 +69,15 @@ static NTSTATUS truenas_acl_open(struct smb2_tree *tree,
 	NTSTATUS status;
 
 	ZERO_STRUCT(cr);
+	/*
+	 * WRITE_DAC suffices to install a DACL, and the owner is granted it
+	 * implicitly. Deliberately do NOT request WRITE_OWNER: ixnas demotes it
+	 * out of owner@/group@/everyone@ in the advertised SD and the owner has no
+	 * implicit WRITE_OWNER, so requesting it would make the open itself
+	 * ACCESS_DENIED once a handle is reopened against an existing object.
+	 */
 	cr.in.desired_access = SEC_STD_READ_CONTROL | SEC_STD_WRITE_DAC |
-			       SEC_STD_WRITE_OWNER | SEC_FILE_READ_DATA;
+			       SEC_FILE_READ_DATA;
 	cr.in.file_attributes = FILE_ATTRIBUTE_NORMAL;
 	cr.in.create_disposition = NTCREATEX_DISP_OPEN_IF;
 	cr.in.share_access = NTCREATEX_SHARE_ACCESS_MASK;
@@ -161,9 +168,16 @@ done:
  * Each Windows access-mask bit set on an owner ALLOW ACE must survive the round
  * trip through the ZFS NFSv4 ACL. ixnas may add bits (it forces SYNCHRONIZE on
  * ALLOW entries, and synthesises DELETE/WRITE_NAMED_ATTRS for special-id
- * entries with WRITE_DATA), so this asserts the returned owner mask is a
+ * entries with WRITE_DATA), so the data/attribute bits are asserted as a
  * superset of what was set, never an exact match. Mirrors the per-bit walk in
  * middleware test_427_smb_acl.py::test_003_test_perms (util_sd.py ACLPerms).
+ *
+ * WRITE_DAC and WRITE_OWNER are the exception: the trustee here is the owner,
+ * so it stores as owner@, and ZFS will not honor those two via owner@. ixnas
+ * therefore demotes them out of the advertised owner mask (presentation only;
+ * the stored ACL keeps them). They are asserted ABSENT on the returned owner
+ * ACE -- see test_truenas_acl_special_demote for the full owner@/group@/
+ * everyone@ vs named-entry contract.
  */
 static bool test_truenas_acl_perm_bits(struct torture_context *tctx,
 				       struct smb2_tree *tree)
@@ -180,19 +194,21 @@ static bool test_truenas_acl_perm_bits(struct torture_context *tctx,
 	static const struct {
 		const char *name;
 		uint32_t mask;
+		bool present;	/* expected on the returned owner ACE? */
 	} cases[] = {
-		{ "READ_DATA",       SEC_FILE_READ_DATA },
-		{ "WRITE_DATA",      SEC_FILE_WRITE_DATA },
-		{ "APPEND_DATA",     SEC_FILE_APPEND_DATA },
-		{ "READ_EA",         SEC_FILE_READ_EA },
-		{ "WRITE_EA",        SEC_FILE_WRITE_EA },
-		{ "EXECUTE",         SEC_FILE_EXECUTE },
-		{ "READ_ATTRIBUTE",  SEC_FILE_READ_ATTRIBUTE },
-		{ "WRITE_ATTRIBUTE", SEC_FILE_WRITE_ATTRIBUTE },
-		{ "DELETE",          SEC_STD_DELETE },
-		{ "READ_CONTROL",    SEC_STD_READ_CONTROL },
-		{ "WRITE_DAC",       SEC_STD_WRITE_DAC },
-		{ "WRITE_OWNER",     SEC_STD_WRITE_OWNER },
+		{ "READ_DATA",       SEC_FILE_READ_DATA,      true },
+		{ "WRITE_DATA",      SEC_FILE_WRITE_DATA,     true },
+		{ "APPEND_DATA",     SEC_FILE_APPEND_DATA,    true },
+		{ "READ_EA",         SEC_FILE_READ_EA,        true },
+		{ "WRITE_EA",        SEC_FILE_WRITE_EA,       true },
+		{ "EXECUTE",         SEC_FILE_EXECUTE,        true },
+		{ "READ_ATTRIBUTE",  SEC_FILE_READ_ATTRIBUTE, true },
+		{ "WRITE_ATTRIBUTE", SEC_FILE_WRITE_ATTRIBUTE, true },
+		{ "DELETE",          SEC_STD_DELETE,          true },
+		{ "READ_CONTROL",    SEC_STD_READ_CONTROL,    true },
+		/* owner@ cannot convey these in ZFS -- demoted from the SD */
+		{ "WRITE_DAC",       SEC_STD_WRITE_DAC,       false },
+		{ "WRITE_OWNER",     SEC_STD_WRITE_OWNER,     false },
 	};
 
 	if (!truenas_acl_enabled(tctx)) {
@@ -245,9 +261,10 @@ static bool test_truenas_acl_perm_bits(struct torture_context *tctx,
 	}
 
 	for (c = 0; c < ARRAY_SIZE(cases); c++) {
-		torture_assert_goto(tctx,
-				    (got_mask & cases[c].mask) == cases[c].mask,
-				    ret, done, cases[c].name);
+		bool ok = cases[c].present ?
+			((got_mask & cases[c].mask) == cases[c].mask) :
+			((got_mask & cases[c].mask) == 0);
+		torture_assert_goto(tctx, ok, ret, done, cases[c].name);
 	}
 
 done:
@@ -301,6 +318,191 @@ done:
 	return ret;
 }
 
+/* Open an existing file read-only (READ_CONTROL is enough to read the SD). */
+static NTSTATUS truenas_acl_open_existing(struct smb2_tree *tree,
+					 struct torture_context *tctx,
+					 const char *fname,
+					 struct smb2_handle *h)
+{
+	struct smb2_create cr;
+	NTSTATUS status;
+
+	ZERO_STRUCT(cr);
+	cr.in.desired_access = SEC_STD_READ_CONTROL | SEC_FILE_READ_DATA;
+	cr.in.file_attributes = FILE_ATTRIBUTE_NORMAL;
+	cr.in.create_disposition = NTCREATEX_DISP_OPEN;		/* must exist */
+	cr.in.share_access = NTCREATEX_SHARE_ACCESS_MASK;
+	cr.in.fname = fname;
+
+	status = smb2_create(tree, tctx, &cr);
+	if (NT_STATUS_IS_OK(status)) {
+		*h = cr.out.file.handle;
+	}
+	return status;
+}
+
+/*
+ * owner@/group@/everyone@ map back to the owner SID, the owning-group SID and
+ * Everyone; their inheritable halves surface as CREATOR OWNER / CREATOR GROUP.
+ * Those are exactly the identities ZFS will not let convey WRITE_ACL/WRITE_OWNER
+ * and that ixnas therefore demotes. Anything else is a named user/group.
+ */
+static bool sd_trustee_is_special(const struct security_descriptor *sd,
+				  const struct dom_sid *trustee)
+{
+	return (sd->owner_sid != NULL && dom_sid_equal(trustee, sd->owner_sid)) ||
+	       (sd->group_sid != NULL && dom_sid_equal(trustee, sd->group_sid)) ||
+	       dom_sid_equal(trustee, &global_sid_World) ||
+	       dom_sid_equal(trustee, &global_sid_Creator_Owner) ||
+	       dom_sid_equal(trustee, &global_sid_Creator_Group);
+}
+
+/*
+ * The advertisement contract. Every special-identity ALLOW ACE must return
+ * WITHOUT WRITE_DAC/WRITE_OWNER. With want_named, also require at least one
+ * named ALLOW ACE that still carries both bits -- proof the demote is scoped to
+ * the special identities and is not a blanket strip.
+ */
+static bool truenas_acl_assert_demote(struct torture_context *tctx,
+				      const struct security_descriptor *sd,
+				      bool want_named)
+{
+	const uint32_t wc = SEC_STD_WRITE_DAC | SEC_STD_WRITE_OWNER;
+	bool saw_special = false, saw_named_full = false;
+	uint32_t i;
+
+	torture_assert(tctx, sd->dacl != NULL, "no DACL returned");
+
+	for (i = 0; i < sd->dacl->num_aces; i++) {
+		const struct security_ace *ace = &sd->dacl->aces[i];
+
+		if (ace->type != SEC_ACE_TYPE_ACCESS_ALLOWED) {
+			continue;
+		}
+
+		if (sd_trustee_is_special(sd, &ace->trustee)) {
+			saw_special = true;
+			torture_assert(tctx, (ace->access_mask & wc) == 0,
+				       "owner@/group@/everyone@ still advertises "
+				       "WRITE_DAC/WRITE_OWNER");
+		} else if ((ace->access_mask & wc) == wc) {
+			saw_named_full = true;
+		}
+	}
+
+	torture_assert(tctx, saw_special,
+		       "no owner@/group@/everyone@ ACE in returned SD");
+	if (want_named) {
+		torture_assert(tctx, saw_named_full,
+			       "named entry lost WRITE_DAC/WRITE_OWNER");
+	}
+	return true;
+}
+
+/*
+ * Core contract over pure SMB: set Full Control (including WRITE_DAC/WRITE_OWNER)
+ * on owner@, group@ and everyone@, read the SD back, and require all three
+ * special identities to return without those two bits. No fixture needed.
+ */
+static bool test_truenas_acl_special_demote(struct torture_context *tctx,
+					    struct smb2_tree *tree)
+{
+	NTSTATUS status;
+	bool ret = true;
+	struct smb2_handle h = {{0}};
+	struct security_descriptor *sd0 = NULL, *sd = NULL, *got = NULL;
+	const char *owner = NULL, *group = NULL, *world = NULL;
+	const char *fname = "acl_special_demote";
+	const uint32_t full = SEC_STD_ALL | SEC_FILE_ALL;
+
+	if (!truenas_acl_enabled(tctx)) {
+		torture_skip(tctx, "requires an ixnas NFSv4-ACL share "
+				   "(--option=torture:acl_nfs4=yes)");
+	}
+
+	smb2_util_unlink(tree, fname);
+	status = truenas_acl_open(tree, tctx, fname, &h);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "create file");
+
+	status = truenas_acl_get(tree, tctx, h,
+				 SECINFO_OWNER | SECINFO_GROUP, &sd0);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "get owner/group");
+	torture_assert_goto(tctx,
+			    sd0->owner_sid != NULL && sd0->group_sid != NULL,
+			    ret, done, "missing owner/group sid");
+
+	owner = dom_sid_string(tctx, sd0->owner_sid);
+	group = dom_sid_string(tctx, sd0->group_sid);
+	world = dom_sid_string(tctx, &global_sid_World);
+
+	/*
+	 * The owner/owning-group SIDs collapse to owner@/group@ and S-1-1-0 maps
+	 * to everyone@ on store, so this lands as a 3-entry special-identity ACL.
+	 */
+	sd = security_descriptor_dacl_create(tctx, 0, owner, NULL,
+			owner, SEC_ACE_TYPE_ACCESS_ALLOWED, full, 0,
+			group, SEC_ACE_TYPE_ACCESS_ALLOWED, full, 0,
+			world, SEC_ACE_TYPE_ACCESS_ALLOWED, full, 0,
+			NULL);
+	torture_assert_goto(tctx, sd != NULL, ret, done, "build dacl");
+
+	status = truenas_acl_set(tree, h, sd);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "set special ACL");
+
+	status = truenas_acl_get(tree, tctx, h,
+				 SECINFO_OWNER | SECINFO_GROUP | SECINFO_DACL,
+				 &got);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "get back ACL");
+
+	ret = truenas_acl_assert_demote(tctx, got, false);
+
+done:
+	smb2_util_close(tree, h);
+	smb2_util_unlink(tree, fname);
+	return ret;
+}
+
+/*
+ * Same contract against an out-of-band fixture (laid down on disk by
+ * truenas_setfacl in the CI runner) that also carries a named user/group with
+ * Full Control: the special identities must be demoted while the named entry
+ * keeps WRITE_DAC/WRITE_OWNER. The runner brackets this with truenas_getfacl to
+ * prove the on-disk ACL is left untouched (advertisement-only). Self-skips
+ * unless given the fixture path.
+ */
+static bool test_truenas_acl_fixture_scope(struct torture_context *tctx,
+					   struct smb2_tree *tree)
+{
+	NTSTATUS status;
+	bool ret = true;
+	struct smb2_handle h = {{0}};
+	struct security_descriptor *got = NULL;
+	const char *fname = torture_setting_string(tctx, "acl_fixture", NULL);
+
+	if (!truenas_acl_enabled(tctx)) {
+		torture_skip(tctx, "requires an ixnas NFSv4-ACL share "
+				   "(--option=torture:acl_nfs4=yes)");
+	}
+	if (fname == NULL) {
+		torture_skip(tctx, "requires --option=torture:acl_fixture=<path> "
+				   "(an on-disk fixture carrying a named entry)");
+	}
+
+	status = truenas_acl_open_existing(tree, tctx, fname, &h);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "open fixture");
+
+	status = truenas_acl_get(tree, tctx, h,
+				 SECINFO_OWNER | SECINFO_GROUP | SECINFO_DACL,
+				 &got);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "get fixture ACL");
+
+	ret = truenas_acl_assert_demote(tctx, got, true);
+
+done:
+	smb2_util_close(tree, h);
+	return ret;
+}
+
 void torture_truenas_acl_suite(struct torture_suite *suite)
 {
 	struct torture_suite *acl = torture_suite_create(suite, "acl");
@@ -311,6 +513,10 @@ void torture_truenas_acl_suite(struct torture_suite *suite)
 				     test_truenas_acl_perm_bits);
 	torture_suite_add_1smb2_test(acl, "null_dacl",
 				     test_truenas_acl_null_dacl);
+	torture_suite_add_1smb2_test(acl, "special_demote",
+				     test_truenas_acl_special_demote);
+	torture_suite_add_1smb2_test(acl, "fixture_scope",
+				     test_truenas_acl_fixture_scope);
 
 	torture_suite_add_suite(suite, acl);
 }


### PR DESCRIPTION
ZFS will not let owner@/group@/everyone@ convey WRITE_ACL or WRITE_OWNER, so do not advertise them there: strip both from those special identities in the SD ixnas returns. Presentation only -- the stored ACL and the set path are untouched, so SMB and NFS clients enforce identically. Named user/group entries keep the bits. Gated by ixnas:zfs_acl_advertise_enforced (default on).