### PR TITLE
NAS-141625 / ixnas: complete fully-open everyone@ ACL sets under privilege

### DIFF
--- a/.github/workflows/scripts/qemu-4-test.sh
+++ b/.github/workflows/scripts/qemu-4-test.sh
@@ -63,15 +63,18 @@ zfs create -o atime=off tank/tm
 chmod 0777 /tank/tm
 # NFSv4-ACL dataset for the ixnas ACL<->Security-Descriptor mapping tests. The
 # system.nfs4_acl_xdr xattr ixnas reads/writes is provided by the TrueNAS ZFS
-# module (built here), so the mapping is testable; aclmode=passthrough lets the
-# client install arbitrary ACLs.
-zfs create -o acltype=nfsv4 -o aclmode=passthrough \
+# module (built here), so the mapping is testable. aclmode=passthrough lets the
+# client install arbitrary ACLs; aclinherit=passthrough matches the TrueNAS SMB
+# default so inherited ACEs keep WRITE_ACL/WRITE_OWNER and no mode-derived
+# owner@/group@ is synthesised -- a child of an everyone@:full dir inherits the
+# full set (as production does), not the restricted-default stripped form.
+zfs create -o acltype=nfsv4 -o aclmode=passthrough -o aclinherit=passthrough \
            -o casesensitivity=insensitive -o atime=off tank/acl
 chmod 0777 /tank/acl
 # NFSv4-ACL dataset for the per-user auto-creation + ACL-inheritance test
 # ([zhome]). Same NFSv4/passthrough setup as tank/acl so an inheritable ACL
 # seeded here propagates into the dataset zfs_core auto-creates on connect.
-zfs create -o acltype=nfsv4 -o aclmode=passthrough \
+zfs create -o acltype=nfsv4 -o aclmode=passthrough -o aclinherit=passthrough \
            -o casesensitivity=insensitive -o atime=off tank/home
 chmod 0777 /tank/home
 # Case-SENSITIVE plain dataset for upstream smb2.* protocol regression, so the
@@ -357,11 +360,11 @@ if python3 -c "import os; os.getxattr('/tank/acl', 'system.nfs4_acl_xdr')" 2>/de
     echo "ERROR: truenas.acl mapping suite FAILED"; tail -80 /var/log/samba4/smbd.log; exit 1
   fi
 
-  # ---- Advertisement-only proof: SMB demotes special identities, on-disk
-  # (NFS view) ACL is left untouched. ixnas strips WRITE_ACL/WRITE_OWNER from
-  # owner@/group@/everyone@ in the SD it reports because ZFS will not honor them
-  # there, while named entries keep them. truenas_setfacl lays down a fixture
-  # carrying both on disk; truenas.acl.fixture_scope checks the SMB view; and
+  # ---- Advertisement-only proof: SMB demotes group@, on-disk (NFS view) ACL is
+  # left untouched. ixnas strips WRITE_ACL/WRITE_OWNER from group@ in the SD it
+  # reports (a group member cannot convey them there), while owner@, everyone@
+  # and named entries keep them. truenas_setfacl lays down a fixture carrying
+  # them on disk; truenas.acl.fixture_scope checks the SMB view; and
   # truenas_getfacl before/after proves the GET never rewrote the stored ACL.
   # Best-effort: truenas_pyos builds a C extension (needs gcc + libbsd-dev), so
   # skip without failing the run if it cannot be installed.
@@ -396,7 +399,7 @@ assert "WRITE_ACL" in o and "WRITE_OWNER" in o, \
     if "$SMBTORTURE" //127.0.0.1/zacl -U 'smbtest%testpass123' \
          --option='torture:acl_nfs4=yes' --option='torture:acl_fixture=pyfix' \
          truenas.acl.fixture_scope; then
-      echo "truenas.acl.fixture_scope PASSED (SMB demotes special, keeps named)"
+      echo "truenas.acl.fixture_scope PASSED (SMB demotes group@, keeps owner@/everyone@/named)"
     else
       echo "ERROR: truenas.acl.fixture_scope FAILED"; tail -80 /var/log/samba4/smbd.log; exit 1
     fi

--- a/source3/modules/vfs_ixnas.c
+++ b/source3/modules/vfs_ixnas.c
@@ -19,6 +19,7 @@
 #include "libcli/security/security.h"
 #include "librpc/gen_ndr/ndr_security.h"
 #include "smbd/smbd.h"
+#include "auth.h"
 #include "system/filesys.h"
 #include "passdb/lookup_sid.h"
 #include "nfs4_acls.h"
@@ -375,6 +376,206 @@ static bool fsp_set_zfsacl(files_struct *fsp, zfsacl_t zfsacl)
 }
 
 /*
+ * True if the ZFS ACL is a "fully open" everyone@ ACL: every entry is an
+ * everyone@ ALLOW entry (no DENY, no owner@/group@/named trustee) and at least
+ * one of them grants the full set of rights on the object itself (not
+ * inherit-only). Such an ACL imposes no real access control -- semantically a
+ * NULL DACL that ixnas materialised as everyone@ -- so it is the one state in
+ * which overriding ZFS's refusal to honor everyone@ WRITE_ACL/WRITE_OWNER is
+ * safe. Tolerates the hidden everyone@:empty entry ixnas adds for inheritance.
+ *
+ * Distinct from ixnas_zfsacl_get_dacl_type()'s strict IXNAS_NULL_DACL (single
+ * entry, no inheritance flags): this also matches the multi-entry, inheritable
+ * everyone@:FULL form. Observed with Avid MediaComposer, which applies an
+ * Everyone:Full DACL (dropping the inherited named-user ACE) to its content
+ * directories and to files created inside them via an SMB2 create-context
+ * security descriptor -- the create-time apply is what fails without the retry.
+ */
+static bool is_open_everyone(zfsacl_t zfsacl)
+{
+	bool ok;
+	uint cnt, i;
+	bool saw_full = false;
+
+	ok = zfsacl_get_acecnt(zfsacl, &cnt);
+	if (!ok || (cnt == 0)) {
+		return false;
+	}
+
+	for (i = 0; i < cnt; i++) {
+		zfsacl_entry_t ae = NULL;
+		zfsace_permset_t perms = 0;
+		zfsace_flagset_t flags = 0;
+		zfsace_who_t who_type = ZFSACL_UNDEFINED_TAG;
+		zfsace_id_t who_id = ZFSACL_UNDEFINED_ID;
+		zfsace_entry_type_t entry_type = 0;
+
+		ok = zfsacl_get_aclentry(zfsacl, i, &ae);
+		if (!ok) {
+			return false;
+		}
+
+		ok = zfsace_get_who(ae, &who_type, &who_id);
+		if (!ok) {
+			return false;
+		}
+		if ((who_type != ZFSACL_EVERYONE) ||
+		    (who_id != ZFSACL_UNDEFINED_ID)) {
+			return false;
+		}
+
+		ok = zfsace_get_entry_type(ae, &entry_type);
+		if (!ok || (entry_type != ZFSACL_ENTRY_TYPE_ALLOW)) {
+			return false;
+		}
+
+		ok = zfsace_get_permset(ae, &perms);
+		if (!ok) {
+			return false;
+		}
+
+		ok = zfsace_get_flagset(ae, &flags);
+		if (!ok) {
+			return false;
+		}
+
+		if ((perms == ZFSACE_FULL_SET) &&
+		    ((flags & ZFSACE_INHERIT_ONLY) == 0)) {
+			saw_full = true;
+		}
+	}
+
+	return saw_full;
+}
+
+/*
+ * True if the ACL grants owner@ full control on the object itself: some owner@
+ * (ZFSACL_USER_OBJ) ALLOW entry with the full permset, not inherit-only. ZFS
+ * strips WRITE_ACL from owner@ and, on a non-trivial ACL, lets only CAP_FOWNER
+ * write it, so the file owner cannot rewrite such an ACL without the privileged
+ * retry below. Coexisting group@/everyone@/named entries are fine.
+ */
+static bool acl_has_owner_full(zfsacl_t zfsacl)
+{
+	bool ok;
+	uint cnt, i;
+
+	ok = zfsacl_get_acecnt(zfsacl, &cnt);
+	if (!ok) {
+		return false;
+	}
+
+	for (i = 0; i < cnt; i++) {
+		zfsacl_entry_t ae = NULL;
+		zfsace_permset_t perms = 0;
+		zfsace_flagset_t flags = 0;
+		zfsace_who_t who_type = ZFSACL_UNDEFINED_TAG;
+		zfsace_id_t who_id = ZFSACL_UNDEFINED_ID;
+		zfsace_entry_type_t entry_type = 0;
+
+		ok = zfsacl_get_aclentry(zfsacl, i, &ae);
+		if (!ok) {
+			return false;
+		}
+		ok = zfsace_get_who(ae, &who_type, &who_id);
+		if (!ok) {
+			return false;
+		}
+		if (who_type != ZFSACL_USER_OBJ) {
+			continue;
+		}
+		ok = zfsace_get_entry_type(ae, &entry_type);
+		if (!ok || (entry_type != ZFSACL_ENTRY_TYPE_ALLOW)) {
+			continue;
+		}
+		ok = zfsace_get_permset(ae, &perms);
+		if (!ok) {
+			return false;
+		}
+		ok = zfsace_get_flagset(ae, &flags);
+		if (!ok) {
+			return false;
+		}
+		if ((perms == ZFSACE_FULL_SET) &&
+		    ((flags & ZFSACE_INHERIT_ONLY) == 0)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* True if the connecting SMB user owns this file. */
+static bool fsp_caller_is_owner(files_struct *fsp)
+{
+	if (!VALID_STAT(fsp->fsp_name->st)) {
+		if (!NT_STATUS_IS_OK(vfs_stat_fsp(fsp))) {
+			return false;
+		}
+	}
+	return fsp->conn->session_info->unix_token->uid ==
+	       fsp->fsp_name->st.st_ex_uid;
+}
+
+/*
+ * Set the ZFS ACL, falling back to a privileged retry when SMB says the caller
+ * may manage the ACL but ZFS refuses. ZFS strips WRITE_ACL/WRITE_OWNER from
+ * owner@/group@/everyone@ ALLOW ACEs and, on a non-trivial ACL, grants WRITE_ACL
+ * only to CAP_FOWNER (zfs_acl.c uses secpolicy_vnode_chown there, not the
+ * owner-allowed secpolicy_vnode_setdac) -- so neither a fully-open everyone@
+ * object nor the owner of a normal file can rewrite the ACL, and fsp_set_zfsacl
+ * gets EACCES/EPERM. When @escalate is set (ixnas:zfs_acl_advertise_enforced, on
+ * by default) complete the set under become_root() (CAP_FOWNER) iff the on-disk
+ * ACL is a fully-open everyone@ ACL (no protection to bypass) or grants owner@
+ * full control and the connecting user owns the file. Only the set is
+ * privileged; the on-disk read is not. Any owner change is done separately by
+ * smb_set_nt_acl_nfs4() and stays ZFS-enforced.
+ */
+static bool fsp_set_zfsacl_escalate(files_struct *fsp, zfsacl_t zfsacl,
+				    bool escalate)
+{
+	int saved_errno, retry_errno;
+	zfsacl_t current = NULL;
+	bool may_escalate = false;
+	bool ok;
+
+	if (fsp_set_zfsacl(fsp, zfsacl)) {
+		return true;
+	}
+	if (!escalate || ((errno != EACCES) && (errno != EPERM))) {
+		return false;
+	}
+	saved_errno = errno;
+
+	/*
+	 * Reading the ACL needs no privilege (owner and everyone@ both hold
+	 * READ_ACL); read it as the user and fail closed unless the caller may
+	 * manage it: a fully-open everyone@ ACL, or an owner@ full-control ACL on
+	 * a file the connecting user owns.
+	 */
+	current = fsp_get_zfsacl(fsp);
+	if (current != NULL) {
+		may_escalate = is_open_everyone(current) ||
+			(acl_has_owner_full(current) &&
+			 fsp_caller_is_owner(fsp));
+		zfsacl_free(&current);
+	}
+	if (!may_escalate) {
+		errno = saved_errno;
+		return false;
+	}
+
+	/* Only the set needs root (CAP_FOWNER); the read above did not. */
+	become_root();
+	ok = fsp_set_zfsacl(fsp, zfsacl);
+	retry_errno = ok ? 0 : errno;
+	unbecome_root();
+
+	errno = retry_errno;
+	return ok;
+}
+
+/*
  * fsp_get_aclbrand() and path_get_aclbrand() both get the ACL brand on the
  * underlying filesystem. In almost all cases we rely on the ACL brand we
  * detected on the initial SMB tree connect, which is preferable to detecting
@@ -521,15 +722,17 @@ static bool zfsentry2smbace(zfsacl_entry_t ae, SMB_ACE4PROP_T *aceprop,
 
 	/*
 	 * Advertisement-only: ZFS will not honor WRITE_ACL/WRITE_OWNER granted
-	 * through owner@/group@/everyone@, so do not report those bits on the
-	 * special identities. This drops them from the SD we present, never from
-	 * what we store (the set path is untouched), so SMB and NFS clients on the
-	 * same dataset keep getting identical, ZFS-enforced access. Named
-	 * user/group entries (flags == 0) still convey these rights and so are
-	 * left intact. Gated by ixnas:zfs_acl_advertise_enforced.
+	 * through group@ (a group member cannot rewrite the ACL via group@), so do
+	 * not report those bits on group@. owner@ and everyone@ keep them: the file
+	 * owner may manage its ACL and a fully-open everyone@ ACL has no protection,
+	 * and fsp_set_zfsacl_escalate() completes those sets under privilege. This
+	 * drops bits only from the SD we present, never from what we store (the set
+	 * path is untouched). Named user/group entries (flags == 0) are untouched.
+	 * Gated by ixnas:zfs_acl_advertise_enforced.
 	 */
 	if (advertise_enforced &&
 	    (aceprop->flags & SMB_ACE4_ID_SPECIAL) &&
+	    (aceprop->who.special_id == SMB_ACE4_WHO_GROUP) &&
 	    (aceprop->aceType == SMB_ACE4_ACCESS_ALLOWED_ACE_TYPE)) {
 		aceprop->aceMask &= ~(SMB_ACE4_WRITE_ACL | SMB_ACE4_WRITE_OWNER);
 	}
@@ -1074,7 +1277,8 @@ static bool ixnas_process_smbacl(vfs_handle_struct *handle,
 	}
 
 	dump_acl_info(zfsacl);
-	if (!fsp_set_zfsacl(fsp, zfsacl)) {
+	if (!fsp_set_zfsacl_escalate(fsp, zfsacl,
+					 config->advertise_enforced_acl)) {
 		DBG_ERR("%s: failed to set acl: %s\n",
 			fsp_str_dbg(fsp), strerror(errno));
 		zfsacl_free(&zfsacl);
@@ -1121,6 +1325,11 @@ static NTSTATUS ixnas_fset_special_dacl(vfs_handle_struct *handle,
 	zfsacl_entry_t placeholder_entry = NULL;
 	bool ok;
 	zfsace_permset_t perms;
+	struct ixnas_config_data *config = NULL;
+
+	SMB_VFS_HANDLE_GET_DATA(handle, config,
+				struct ixnas_config_data,
+				return NT_STATUS_INTERNAL_ERROR);
 
 	switch (dtype) {
 	case IXNAS_NULL_DACL:
@@ -1162,7 +1371,8 @@ static NTSTATUS ixnas_fset_special_dacl(vfs_handle_struct *handle,
 	}
 
 	dump_acl_info(zfsacl);
-	if (!fsp_set_zfsacl(fsp, zfsacl)) {
+	if (!fsp_set_zfsacl_escalate(fsp, zfsacl,
+					 config->advertise_enforced_acl)) {
 		DBG_ERR("%s: failed to set acl: %s\n",
 			fsp_str_dbg(fsp), strerror(errno));
 		zfsacl_free(&zfsacl);
@@ -1494,9 +1704,13 @@ static int ixnas_connect(struct vfs_handle_struct *handle,
 	}
 
 	/*
-	 * Present only the WRITE_ACL/WRITE_OWNER that ZFS will actually honor:
-	 * strip those bits from owner@/group@/everyone@ in the SD we report (not
-	 * from what we store). Default on; set to no to advertise the raw ACL.
+	 * Reconcile the SMB ACL view and set operations with what the ZFS backend
+	 * actually enforces. On (default): strip the WRITE_ACL/WRITE_OWNER that ZFS
+	 * won't honor from owner@/group@/everyone@ in the SD we report (not from
+	 * what we store) -- except for a fully-open everyone@ ACL, which we
+	 * advertise in full and whose DACL writes we complete under privilege (see
+	 * is_open_everyone() / fsp_set_zfsacl_escalate()). Off: raw passthrough
+	 * of the stored ACL, no demotion and no privileged retry.
 	 */
 	config->advertise_enforced_acl = lp_parm_bool(SNUM(handle->conn),
 			"ixnas", "zfs_acl_advertise_enforced", true);

--- a/source4/torture/truenas/truenas_acl.c
+++ b/source4/torture/truenas/truenas_acl.c
@@ -172,12 +172,12 @@ done:
  * superset of what was set, never an exact match. Mirrors the per-bit walk in
  * middleware test_427_smb_acl.py::test_003_test_perms (util_sd.py ACLPerms).
  *
- * WRITE_DAC and WRITE_OWNER are the exception: the trustee here is the owner,
- * so it stores as owner@, and ZFS will not honor those two via owner@. ixnas
- * therefore demotes them out of the advertised owner mask (presentation only;
- * the stored ACL keeps them). They are asserted ABSENT on the returned owner
- * ACE -- see test_truenas_acl_special_demote for the full owner@/group@/
- * everyone@ vs named-entry contract.
+ * WRITE_DAC and WRITE_OWNER: the trustee here is the owner, so it stores as
+ * owner@. ixnas demotes only group@ now, so the owner ACE keeps both bits (the
+ * owner may manage its own ACL, completed under privilege by ixnas). They are
+ * asserted PRESENT on the returned owner ACE -- see
+ * test_truenas_acl_special_demote for the full owner@/group@/everyone@ vs
+ * named-entry contract.
  */
 static bool test_truenas_acl_perm_bits(struct torture_context *tctx,
 				       struct smb2_tree *tree)
@@ -206,9 +206,9 @@ static bool test_truenas_acl_perm_bits(struct torture_context *tctx,
 		{ "WRITE_ATTRIBUTE", SEC_FILE_WRITE_ATTRIBUTE, true },
 		{ "DELETE",          SEC_STD_DELETE,          true },
 		{ "READ_CONTROL",    SEC_STD_READ_CONTROL,    true },
-		/* owner@ cannot convey these in ZFS -- demoted from the SD */
-		{ "WRITE_DAC",       SEC_STD_WRITE_DAC,       false },
-		{ "WRITE_OWNER",     SEC_STD_WRITE_OWNER,     false },
+		/* owner@ keeps these now -- ixnas demotes only group@ */
+		{ "WRITE_DAC",       SEC_STD_WRITE_DAC,       true },
+		{ "WRITE_OWNER",     SEC_STD_WRITE_OWNER,     true },
 	};
 
 	if (!truenas_acl_enabled(tctx)) {
@@ -342,33 +342,20 @@ static NTSTATUS truenas_acl_open_existing(struct smb2_tree *tree,
 }
 
 /*
+ * The advertisement contract after ixnas's group@-only demote: the group@ ALLOW
+ * ACE returns WITHOUT WRITE_DAC/WRITE_OWNER, while owner@ and everyone@ keep
+ * them (the owner may manage its ACL; a fully-open everyone@ has no protection).
  * owner@/group@/everyone@ map back to the owner SID, the owning-group SID and
- * Everyone; their inheritable halves surface as CREATOR OWNER / CREATOR GROUP.
- * Those are exactly the identities ZFS will not let convey WRITE_ACL/WRITE_OWNER
- * and that ixnas therefore demotes. Anything else is a named user/group.
- */
-static bool sd_trustee_is_special(const struct security_descriptor *sd,
-				  const struct dom_sid *trustee)
-{
-	return (sd->owner_sid != NULL && dom_sid_equal(trustee, sd->owner_sid)) ||
-	       (sd->group_sid != NULL && dom_sid_equal(trustee, sd->group_sid)) ||
-	       dom_sid_equal(trustee, &global_sid_World) ||
-	       dom_sid_equal(trustee, &global_sid_Creator_Owner) ||
-	       dom_sid_equal(trustee, &global_sid_Creator_Group);
-}
-
-/*
- * The advertisement contract. Every special-identity ALLOW ACE must return
- * WITHOUT WRITE_DAC/WRITE_OWNER. With want_named, also require at least one
- * named ALLOW ACE that still carries both bits -- proof the demote is scoped to
- * the special identities and is not a blanket strip.
+ * Everyone. With want_named, also require a named ALLOW ACE that carries both
+ * bits -- proof the demote is scoped to group@ and is not a blanket strip.
  */
 static bool truenas_acl_assert_demote(struct torture_context *tctx,
 				      const struct security_descriptor *sd,
 				      bool want_named)
 {
 	const uint32_t wc = SEC_STD_WRITE_DAC | SEC_STD_WRITE_OWNER;
-	bool saw_special = false, saw_named_full = false;
+	bool saw_owner = false, saw_group = false, saw_world = false;
+	bool saw_named_full = false;
 	uint32_t i;
 
 	torture_assert(tctx, sd->dacl != NULL, "no DACL returned");
@@ -380,18 +367,28 @@ static bool truenas_acl_assert_demote(struct torture_context *tctx,
 			continue;
 		}
 
-		if (sd_trustee_is_special(sd, &ace->trustee)) {
-			saw_special = true;
+		if (sd->group_sid != NULL &&
+		    dom_sid_equal(&ace->trustee, sd->group_sid)) {
+			saw_group = true;
 			torture_assert(tctx, (ace->access_mask & wc) == 0,
-				       "owner@/group@/everyone@ still advertises "
+				       "group@ still advertises "
 				       "WRITE_DAC/WRITE_OWNER");
+		} else if (sd->owner_sid != NULL &&
+			   dom_sid_equal(&ace->trustee, sd->owner_sid)) {
+			saw_owner = true;
+			torture_assert(tctx, (ace->access_mask & wc) == wc,
+				       "owner@ lost WRITE_DAC/WRITE_OWNER");
+		} else if (dom_sid_equal(&ace->trustee, &global_sid_World)) {
+			saw_world = true;
+			torture_assert(tctx, (ace->access_mask & wc) == wc,
+				       "everyone@ lost WRITE_DAC/WRITE_OWNER");
 		} else if ((ace->access_mask & wc) == wc) {
 			saw_named_full = true;
 		}
 	}
 
-	torture_assert(tctx, saw_special,
-		       "no owner@/group@/everyone@ ACE in returned SD");
+	torture_assert(tctx, saw_owner && saw_group && saw_world,
+		       "missing owner@/group@/everyone@ ACE in returned SD");
 	if (want_named) {
 		torture_assert(tctx, saw_named_full,
 			       "named entry lost WRITE_DAC/WRITE_OWNER");
@@ -401,8 +398,9 @@ static bool truenas_acl_assert_demote(struct torture_context *tctx,
 
 /*
  * Core contract over pure SMB: set Full Control (including WRITE_DAC/WRITE_OWNER)
- * on owner@, group@ and everyone@, read the SD back, and require all three
- * special identities to return without those two bits. No fixture needed.
+ * on owner@, group@ and everyone@, read the SD back, and require group@ to
+ * return without those two bits while owner@ and everyone@ keep them. No fixture
+ * needed.
  */
 static bool test_truenas_acl_special_demote(struct torture_context *tctx,
 					    struct smb2_tree *tree)
@@ -503,6 +501,188 @@ done:
 	return ret;
 }
 
+/*
+ * Avid MediaComposer content-directory pattern, observed on the wire:
+ *
+ *   1. SMB2 SetInfo(SECURITY, DACL) on a directory installing a DACL-only SD:
+ *      one ACE, Everyone (S-1-1-0) ACCESS_ALLOWED, OI|CI, mask 0x101fffff
+ *      (Full), control 0x8004 (SELF_RELATIVE|DACL_PRESENT, not protected), no
+ *      owner/group -- i.e. it drops the inherited owner@/group@/named ACEs.
+ *   2. SMB2 Create of a file inside that directory (disposition OVERWRITE_IF,
+ *      desired access 0x0012019f = read/write data + READ_CONTROL, NO WRITE_DAC
+ *      or WRITE_OWNER) carrying a "SecD" (SMB2_CREATE_SD_BUFFER) create-context
+ *      holding the same Everyone:Full DACL. This returned STATUS_ACCESS_DENIED.
+ *
+ * ixnas applies that create-time SD via SMB_VFS_FSET_NT_ACL. The child inherits
+ * the parent's non-trivial everyone@:full ACL, and ZFS grants WRITE_ACL on a
+ * non-trivial ACL only to CAP_FOWNER (secpolicy_vnode_chown) -- so even the
+ * connecting user, as the child's owner, is refused, and without the
+ * open-everyone privileged retry (fsp_set_zfsacl_open_everyone) the create rolls
+ * back to ACCESS_DENIED.
+ *
+ * Asserts the create succeeds and the DACL round-trips. NOTE: the become_root
+ * retry only fires on a TrueNAS-patched kernel that enforces the NFSv4 ACL; on a
+ * stock CI runner (no enforcement) the create succeeds without the retry, so
+ * this still validates the create-context SD apply path and its mapping.
+ */
+static bool test_truenas_acl_create_ctx_open_everyone(struct torture_context *tctx,
+						      struct smb2_tree *tree)
+{
+	NTSTATUS status;
+	bool ret = true;
+	struct smb2_handle dh = {{0}};
+	struct smb2_handle fh = {{0}};
+	struct smb2_create cr;
+	struct security_descriptor *sd = NULL, *got = NULL;
+	const char *world = NULL;
+	const char *dname = "acl_open_everyone_dir";
+	const char *fname = "acl_open_everyone_dir\\creating_ctx";
+	const uint32_t full = SEC_STD_ALL | SEC_FILE_ALL;
+	uint32_t i;
+	bool saw_world = false;
+
+	if (!truenas_acl_enabled(tctx)) {
+		torture_skip(tctx, "requires an ixnas NFSv4-ACL share "
+				   "(--option=torture:acl_nfs4=yes)");
+	}
+
+	smb2_deltree(tree, dname);
+
+	status = torture_smb2_testdir(tree, dname, &dh);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "create dir");
+
+	/* Everyone:Full, inheritable, DACL-only -- step 1 above. */
+	world = dom_sid_string(tctx, &global_sid_World);
+	sd = security_descriptor_dacl_create(tctx, 0, NULL, NULL,
+			world, SEC_ACE_TYPE_ACCESS_ALLOWED, full,
+			SEC_ACE_FLAG_OBJECT_INHERIT | SEC_ACE_FLAG_CONTAINER_INHERIT,
+			NULL);
+	torture_assert_goto(tctx, sd != NULL, ret, done, "build dacl");
+
+	status = truenas_acl_set(tree, dh, sd);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "set dir DACL");
+
+	/*
+	 * Create a file inside it carrying the same Everyone:Full DACL as a
+	 * "SecD" create-context SD -- step 2 above (Overwrite-If, read/write, no
+	 * WRITE_DAC/WRITE_OWNER). Must NOT be ACCESS_DENIED.
+	 */
+	ZERO_STRUCT(cr);
+	cr.in.desired_access = SEC_FILE_READ_DATA | SEC_FILE_WRITE_DATA |
+			       SEC_STD_READ_CONTROL;
+	cr.in.file_attributes = FILE_ATTRIBUTE_NORMAL;
+	cr.in.create_disposition = NTCREATEX_DISP_OVERWRITE_IF;
+	cr.in.share_access = NTCREATEX_SHARE_ACCESS_MASK;
+	cr.in.fname = fname;
+	cr.in.sec_desc = sd;
+
+	status = smb2_create(tree, tctx, &cr);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+					"create file with Everyone:Full SecD SD");
+	fh = cr.out.file.handle;
+
+	/*
+	 * The applied DACL round-trips as "everyone has full access". A lone
+	 * everyone@:full on a file is stored as a single flags==0 ACE, which ixnas
+	 * maps back to a NULL DACL (SEC_DESC_DACL_PRESENT, dacl==NULL) -- the
+	 * Windows "Everyone / full control / no ACL" form (see acl.null_dacl).
+	 * Accept that, or an explicit Everyone ALLOW ACE; both mean it was applied.
+	 */
+	status = truenas_acl_get(tree, tctx, fh,
+				 SECINFO_OWNER | SECINFO_GROUP | SECINFO_DACL, &got);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "get back SD");
+	if (got->dacl == NULL) {
+		torture_assert_goto(tctx,
+			(got->type & SEC_DESC_DACL_PRESENT) != 0, ret, done,
+			"no DACL present after create-context set");
+	} else {
+		for (i = 0; i < got->dacl->num_aces; i++) {
+			const struct security_ace *ace = &got->dacl->aces[i];
+
+			if ((ace->type == SEC_ACE_TYPE_ACCESS_ALLOWED) &&
+			    dom_sid_equal(&ace->trustee, &global_sid_World)) {
+				saw_world = true;
+			}
+		}
+		torture_assert_goto(tctx, saw_world, ret, done,
+			"Everyone ACE missing after create-context set");
+	}
+
+done:
+	smb2_util_close(tree, fh);
+	smb2_util_close(tree, dh);
+	smb2_deltree(tree, dname);
+	return ret;
+}
+
+/*
+ * The file owner may rewrite the ACL of their own file even once it is
+ * non-trivial -- which ZFS otherwise refuses (WRITE_ACL on a non-trivial ACL
+ * needs CAP_FOWNER, and owner@ does not convey it). Set [owner@:full,
+ * group@:full] (trivial->non-trivial, allowed by secpolicy_vnode_setdac), then
+ * rewrite it to [owner@:full, group@:read]: the second set is on a non-trivial
+ * ACL, so ZFS refuses the owner's WRITE_ACL and it must complete via ixnas's
+ * become_root retry (gated on owner@ full-control + caller is the owner).
+ *
+ * NOTE: the retry only fires on a TrueNAS-patched enforcing kernel; on a stock
+ * CI runner the second set succeeds without it (still validates the mapping).
+ */
+static bool test_truenas_acl_owner_full_escalate(struct torture_context *tctx,
+						 struct smb2_tree *tree)
+{
+	NTSTATUS status;
+	bool ret = true;
+	struct smb2_handle h = {{0}};
+	struct security_descriptor *sd0 = NULL, *sd = NULL;
+	const char *owner = NULL, *group = NULL;
+	const char *fname = "acl_owner_full_escalate";
+	const uint32_t full = SEC_STD_ALL | SEC_FILE_ALL;
+
+	if (!truenas_acl_enabled(tctx)) {
+		torture_skip(tctx, "requires an ixnas NFSv4-ACL share "
+				   "(--option=torture:acl_nfs4=yes)");
+	}
+
+	smb2_util_unlink(tree, fname);
+	status = truenas_acl_open(tree, tctx, fname, &h);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "create file");
+
+	status = truenas_acl_get(tree, tctx, h,
+				 SECINFO_OWNER | SECINFO_GROUP, &sd0);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done, "get owner/group");
+	torture_assert_goto(tctx,
+			    sd0->owner_sid != NULL && sd0->group_sid != NULL,
+			    ret, done, "missing owner/group sid");
+	owner = dom_sid_string(tctx, sd0->owner_sid);
+	group = dom_sid_string(tctx, sd0->group_sid);
+
+	/* Establish a non-trivial ACL (allowed: the file's ACL is still trivial). */
+	sd = security_descriptor_dacl_create(tctx, 0, owner, NULL,
+			owner, SEC_ACE_TYPE_ACCESS_ALLOWED, full, 0,
+			group, SEC_ACE_TYPE_ACCESS_ALLOWED, full, 0,
+			NULL);
+	torture_assert_goto(tctx, sd != NULL, ret, done, "build dacl 1");
+	status = truenas_acl_set(tree, h, sd);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+					"set initial non-trivial ACL");
+
+	/* Rewrite it -- now the on-disk ACL is non-trivial; needs the retry. */
+	sd = security_descriptor_dacl_create(tctx, 0, owner, NULL,
+			owner, SEC_ACE_TYPE_ACCESS_ALLOWED, full, 0,
+			group, SEC_ACE_TYPE_ACCESS_ALLOWED,
+			SEC_FILE_READ_DATA, 0,
+			NULL);
+	torture_assert_goto(tctx, sd != NULL, ret, done, "build dacl 2");
+	status = truenas_acl_set(tree, h, sd);
+	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
+					"rewrite non-trivial owner ACL");
+
+done:
+	smb2_util_close(tree, h);
+	smb2_util_unlink(tree, fname);
+	return ret;
+}
+
 void torture_truenas_acl_suite(struct torture_suite *suite)
 {
 	struct torture_suite *acl = torture_suite_create(suite, "acl");
@@ -517,6 +697,10 @@ void torture_truenas_acl_suite(struct torture_suite *suite)
 				     test_truenas_acl_special_demote);
 	torture_suite_add_1smb2_test(acl, "fixture_scope",
 				     test_truenas_acl_fixture_scope);
+	torture_suite_add_1smb2_test(acl, "create_ctx_open_everyone",
+				     test_truenas_acl_create_ctx_open_everyone);
+	torture_suite_add_1smb2_test(acl, "owner_full_escalate",
+				     test_truenas_acl_owner_full_escalate);
 
 	torture_suite_add_suite(suite, acl);
 }


### PR DESCRIPTION
Avid MediaComposer installs a DACL-only Everyone:Full security descriptor on its content directories (dropping the inherited named-user ACE) and attaches the same SD as an SMB2 "SecD" create-context when creating files inside them. ixnas applies that create-time SD via SMB_VFS_FSET_NT_ACL.

Detect this fully-open everyone@ shape (is_open_everyone) and, on a WRITE_ACL failure, complete the set under become_root().

owner@ and everyone@ should be able to manage the ACL: the owner holds implicit WRITE_DAC in SMB, and a fully-open everyone@ ACL has no protection to preserve. So advertise those bits and make them work.

SET: on a ZFS EACCES/EPERM, read the current on-disk ACL unprivileged SET: on a ZFS EACCES/EPERM, read the current on-disk ACL unprivileged and complete the set under become_root() (CAP_FOWNER) when it is a fully-open everyone@ ACL, or grants owner@ full control and the connecting user owns the file. DACL-only; the owner/group chown in smb_set_nt_acl_nfs4 stays ZFS-enforced. Both halves are gated by ixnas:zfs_acl_advertise_enforced (default on; off = raw passthrough).